### PR TITLE
feat: add pendle pt swapper

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,7 @@ libs = ['lib']
 
 optimizer = true
 optimizer_runs = 200
+evm_version = "cancun"
 
 auto_detect_remappings = false
 
@@ -20,3 +21,6 @@ remappings = [
 [fuzz]
 runs = 250
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config
+
+[rpc_endpoints]
+mainnet = "${ETH_RPC_URL}"

--- a/src/interfaces/Pendle/IPendle.sol
+++ b/src/interfaces/Pendle/IPendle.sol
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.18;
+
+// ============ Pendle Structs ============
+
+enum SwapType {
+    NONE,
+    KYBERSWAP,
+    ONE_INCH,
+    ETH_WETH
+}
+
+struct SwapData {
+    SwapType swapType;
+    address extRouter;
+    bytes extCalldata;
+    bool needScale;
+}
+
+struct TokenInput {
+    address tokenIn;
+    uint256 netTokenIn;
+    address tokenMintSy;
+    address pendleSwap;
+    SwapData swapData;
+}
+
+struct TokenOutput {
+    address tokenOut;
+    uint256 minTokenOut;
+    address tokenRedeemSy;
+    address pendleSwap;
+    SwapData swapData;
+}
+
+struct ApproxParams {
+    uint256 guessMin;
+    uint256 guessMax;
+    uint256 guessOffchain;
+    uint256 maxIteration;
+    uint256 eps;
+}
+
+struct FillOrderParams {
+    Order order;
+    bytes signature;
+    uint256 makingAmount;
+}
+
+struct Order {
+    uint256 salt;
+    uint256 expiry;
+    uint256 nonce;
+    OrderType orderType;
+    address token;
+    address YT;
+    address maker;
+    address receiver;
+    uint256 makingAmount;
+    uint256 lnImpliedRate;
+    uint256 failSafeRate;
+    bytes permit;
+}
+
+enum OrderType {
+    SY_FOR_PT,
+    PT_FOR_SY,
+    SY_FOR_YT,
+    YT_FOR_SY
+}
+
+struct LimitOrderData {
+    address limitRouter;
+    uint256 epsSkipMarket;
+    FillOrderParams[] normalFills;
+    FillOrderParams[] flashFills;
+    bytes optData;
+}
+
+// ============ Pendle Interfaces ============
+
+interface IStandardizedYield {
+    function deposit(
+        address receiver,
+        address tokenIn,
+        uint256 amountTokenToDeposit,
+        uint256 minSharesOut
+    ) external payable returns (uint256 amountSharesOut);
+
+    function redeem(
+        address receiver,
+        uint256 amountSharesToRedeem,
+        address tokenOut,
+        uint256 minTokenOut,
+        bool burnFromInternalBalance
+    ) external returns (uint256 amountTokenOut);
+
+    function getTokensIn() external view returns (address[] memory);
+
+    function getTokensOut() external view returns (address[] memory);
+
+    function yieldToken() external view returns (address);
+}
+
+interface IPPrincipalToken {
+    function SY() external view returns (address);
+
+    function YT() external view returns (address);
+
+    function expiry() external view returns (uint256);
+
+    function isExpired() external view returns (bool);
+}
+
+interface IPYieldToken {
+    function SY() external view returns (address);
+
+    function PT() external view returns (address);
+
+    function expiry() external view returns (uint256);
+
+    function isExpired() external view returns (bool);
+
+    function redeemPY(address receiver) external returns (uint256 amountSyOut);
+}
+
+interface IPMarket {
+    function readTokens()
+        external
+        view
+        returns (
+            IStandardizedYield _SY,
+            IPPrincipalToken _PT,
+            IPYieldToken _YT
+        );
+
+    function isExpired() external view returns (bool);
+
+    function expiry() external view returns (uint256);
+}
+
+interface IPendleRouter {
+    function swapExactTokenForPt(
+        address receiver,
+        address market,
+        uint256 minPtOut,
+        ApproxParams calldata guessPtOut,
+        TokenInput calldata input,
+        LimitOrderData calldata limit
+    )
+        external
+        payable
+        returns (uint256 netPtOut, uint256 netSyFee, uint256 netSyInterm);
+
+    function swapExactPtForToken(
+        address receiver,
+        address market,
+        uint256 exactPtIn,
+        TokenOutput calldata output,
+        LimitOrderData calldata limit
+    )
+        external
+        returns (uint256 netTokenOut, uint256 netSyFee, uint256 netSyInterm);
+
+    function redeemPyToToken(
+        address receiver,
+        address YT,
+        uint256 netPyIn,
+        TokenOutput calldata output
+    ) external returns (uint256 netTokenOut, uint256 netSyInterm);
+
+    function swapExactSyForPt(
+        address receiver,
+        address market,
+        uint256 exactSyIn,
+        uint256 minPtOut,
+        ApproxParams calldata guessPtOut,
+        LimitOrderData calldata limit
+    ) external returns (uint256 netPtOut, uint256 netSyFee);
+
+    function swapExactPtForSy(
+        address receiver,
+        address market,
+        uint256 exactPtIn,
+        uint256 minSyOut,
+        LimitOrderData calldata limit
+    ) external returns (uint256 netSyOut, uint256 netSyFee);
+
+    function redeemPyToSy(
+        address receiver,
+        address YT,
+        uint256 netPyIn,
+        uint256 minSyOut
+    ) external returns (uint256 netSyOut);
+}

--- a/src/swappers/PendleSwapper.sol
+++ b/src/swappers/PendleSwapper.sol
@@ -193,12 +193,9 @@ contract PendleSwapper is BaseSwapper {
      *   Uses ~180k gas for the approximation.
      * @param _amountIn The input amount used to calculate guessMax.
      */
-    function _getDefaultApproxParams(uint256 _amountIn)
-        internal
-        view
-        virtual
-        returns (ApproxParams memory)
-    {
+    function _getDefaultApproxParams(
+        uint256 _amountIn
+    ) internal view virtual returns (ApproxParams memory) {
         uint256 _guessMax = guessMaxMultiplier == 0
             ? type(uint256).max
             : _amountIn * guessMaxMultiplier;

--- a/src/swappers/PendleSwapper.sol
+++ b/src/swappers/PendleSwapper.sol
@@ -67,7 +67,7 @@ contract PendleSwapper is BaseSwapper {
      * @param _minAmountOut The minimum amount of `_to` to receive.
      * @return _amountOut The actual amount of `_to` received.
      */
-    function _swapFrom(
+    function _pendleSwapFrom(
         address _from,
         address _to,
         uint256 _amountIn,

--- a/src/swappers/PendleSwapper.sol
+++ b/src/swappers/PendleSwapper.sol
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.18;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {BaseSwapper} from "./BaseSwapper.sol";
+import {
+    IPendleRouter,
+    IPMarket,
+    IPYieldToken,
+    ApproxParams,
+    TokenInput,
+    TokenOutput,
+    SwapData,
+    SwapType,
+    LimitOrderData,
+    FillOrderParams
+} from "../interfaces/Pendle/IPendle.sol";
+
+/**
+ * @title PendleSwapper
+ * @author yearn.fi
+ * @dev This is a contract that can be inherited by any tokenized
+ *   strategy that would like to use Pendle for swapping tokens to/from
+ *   Principal Tokens (PT).
+ *
+ *   The swapper supports:
+ *   - Buying PT: swap underlying/SY token -> PT via Pendle AMM
+ *   - Selling PT (pre-expiry): swap PT -> underlying via Pendle AMM
+ *   - Redeeming PT (post-expiry): redeem PT -> underlying directly
+ *
+ *   The swapper automatically detects the direction of the swap based on
+ *   which token is registered in the markets mapping.
+ *
+ *   Multiple PT markets can be registered, allowing the same swapper
+ *   instance to work with different PT tokens.
+ */
+contract PendleSwapper is BaseSwapper {
+    using SafeERC20 for ERC20;
+
+    // Pendle Router V4 - same address across all supported chains
+    address public pendleRouter = 0x888888888889758F76e7103c6CbF23ABbF58F946;
+
+    // Market registry: PT address => market address
+    mapping(address => address) public markets;
+
+    /**
+     * @dev Register a PT token with its corresponding market.
+     * @param _pt The address of the Principal Token.
+     * @param _market The address of the Pendle market for this PT.
+     */
+    function _setMarket(address _pt, address _market) internal virtual {
+        markets[_pt] = _market;
+    }
+
+    /**
+     * @dev Swap tokens using Pendle.
+     *
+     *   If `_to` is a registered PT, this buys PT with `_from` token.
+     *   If `_from` is a registered PT, this sells PT for `_to` token.
+     *   For selling, automatically uses AMM if pre-expiry or redemption if post-expiry.
+     *
+     * @param _from The token to swap from.
+     * @param _to The token to swap to.
+     * @param _amountIn The amount of `_from` to swap.
+     * @param _minAmountOut The minimum amount of `_to` to receive.
+     * @return _amountOut The actual amount of `_to` received.
+     */
+    function _swapFrom(
+        address _from,
+        address _to,
+        uint256 _amountIn,
+        uint256 _minAmountOut
+    ) internal virtual returns (uint256 _amountOut) {
+        if (_amountIn == 0 || _amountIn < minAmountToSell) {
+            return 0;
+        }
+
+        // Check if we're buying PT (_to is a registered PT)
+        address market = markets[_to];
+        if (market != address(0)) {
+            return _buyPt(_from, _to, market, _amountIn, _minAmountOut);
+        }
+
+        // Check if we're selling PT (_from is a registered PT)
+        market = markets[_from];
+        if (market != address(0)) {
+            if (IPMarket(market).isExpired()) {
+                return _redeemPt(_from, market, _to, _amountIn, _minAmountOut);
+            } else {
+                return _sellPt(_from, market, _to, _amountIn, _minAmountOut);
+            }
+        }
+
+        revert("PendleSwapper: unknown market");
+    }
+
+    /**
+     * @dev Buy PT tokens using the Pendle AMM.
+     * @param _tokenIn The input token (underlying or SY-compatible token).
+     * @param _market The Pendle market address.
+     * @param _amountIn Amount of input token to spend.
+     * @param _minPtOut Minimum PT to receive.
+     * @return _amountOut Amount of PT received.
+     */
+    function _buyPt(
+        address _tokenIn,
+        address, // _pt - not used, market determines PT
+        address _market,
+        uint256 _amountIn,
+        uint256 _minPtOut
+    ) internal virtual returns (uint256 _amountOut) {
+        _checkAllowance(pendleRouter, _tokenIn, _amountIn);
+
+        (uint256 netPtOut, , ) = IPendleRouter(pendleRouter).swapExactTokenForPt(
+            address(this),
+            _market,
+            _minPtOut,
+            _getDefaultApproxParams(),
+            _getSimpleTokenInput(_tokenIn, _amountIn),
+            _getEmptyLimitOrderData()
+        );
+
+        _amountOut = netPtOut;
+    }
+
+    /**
+     * @dev Sell PT tokens via the Pendle AMM (pre-expiry).
+     * @param _pt The PT token to sell.
+     * @param _market The Pendle market address.
+     * @param _tokenOut The output token to receive.
+     * @param _amountIn Amount of PT to sell.
+     * @param _minTokenOut Minimum output token to receive.
+     * @return _amountOut Amount of output token received.
+     */
+    function _sellPt(
+        address _pt,
+        address _market,
+        address _tokenOut,
+        uint256 _amountIn,
+        uint256 _minTokenOut
+    ) internal virtual returns (uint256 _amountOut) {
+        _checkAllowance(pendleRouter, _pt, _amountIn);
+
+        (uint256 netTokenOut, , ) = IPendleRouter(pendleRouter).swapExactPtForToken(
+            address(this),
+            _market,
+            _amountIn,
+            _getSimpleTokenOutput(_tokenOut, _minTokenOut),
+            _getEmptyLimitOrderData()
+        );
+
+        _amountOut = netTokenOut;
+    }
+
+    /**
+     * @dev Redeem PT tokens after expiry.
+     * @param _pt The PT token to redeem.
+     * @param _market The Pendle market address (used to get YT address).
+     * @param _tokenOut The output token to receive.
+     * @param _amountIn Amount of PT to redeem.
+     * @param _minTokenOut Minimum output token to receive.
+     * @return _amountOut Amount of output token received.
+     */
+    function _redeemPt(
+        address _pt,
+        address _market,
+        address _tokenOut,
+        uint256 _amountIn,
+        uint256 _minTokenOut
+    ) internal virtual returns (uint256 _amountOut) {
+        (, , IPYieldToken YT) = IPMarket(_market).readTokens();
+
+        _checkAllowance(pendleRouter, _pt, _amountIn);
+
+        (uint256 netTokenOut, ) = IPendleRouter(pendleRouter).redeemPyToToken(
+            address(this),
+            address(YT),
+            _amountIn,
+            _getSimpleTokenOutput(_tokenOut, _minTokenOut)
+        );
+
+        _amountOut = netTokenOut;
+    }
+
+    /**
+     * @dev Returns the default ApproxParams for PT swaps.
+     *   These are Pendle's recommended defaults that work without offchain hints.
+     *   Uses ~180k gas for the approximation.
+     */
+    function _getDefaultApproxParams()
+        internal
+        pure
+        virtual
+        returns (ApproxParams memory)
+    {
+        return
+            ApproxParams({
+                guessMin: 0,
+                guessMax: type(uint256).max,
+                guessOffchain: 0,
+                maxIteration: 256,
+                eps: 1e14 // 0.01%
+            });
+    }
+
+    /**
+     * @dev Returns an empty LimitOrderData struct.
+     *   Limit order integration is not supported in this base swapper.
+     */
+    function _getEmptyLimitOrderData()
+        internal
+        pure
+        virtual
+        returns (LimitOrderData memory)
+    {
+        return
+            LimitOrderData({
+                limitRouter: address(0),
+                epsSkipMarket: 0,
+                normalFills: new FillOrderParams[](0),
+                flashFills: new FillOrderParams[](0),
+                optData: ""
+            });
+    }
+
+    /**
+     * @dev Creates a simple TokenInput struct for direct token deposits.
+     *   This assumes the input token is directly accepted by the SY contract.
+     * @param _tokenIn The input token address.
+     * @param _amount The amount of tokens.
+     */
+    function _getSimpleTokenInput(
+        address _tokenIn,
+        uint256 _amount
+    ) internal pure virtual returns (TokenInput memory) {
+        return
+            TokenInput({
+                tokenIn: _tokenIn,
+                netTokenIn: _amount,
+                tokenMintSy: _tokenIn, // Same as tokenIn for direct deposits
+                pendleSwap: address(0), // No external swap needed
+                swapData: SwapData({
+                    swapType: SwapType.NONE,
+                    extRouter: address(0),
+                    extCalldata: "",
+                    needScale: false
+                })
+            });
+    }
+
+    /**
+     * @dev Creates a simple TokenOutput struct for direct token redemptions.
+     *   This assumes the output token is directly redeemable from the SY contract.
+     * @param _tokenOut The output token address.
+     * @param _minTokenOut Minimum amount of tokens to receive.
+     */
+    function _getSimpleTokenOutput(
+        address _tokenOut,
+        uint256 _minTokenOut
+    ) internal pure virtual returns (TokenOutput memory) {
+        return
+            TokenOutput({
+                tokenOut: _tokenOut,
+                minTokenOut: _minTokenOut,
+                tokenRedeemSy: _tokenOut, // Same as tokenOut for direct redemptions
+                pendleSwap: address(0), // No external swap needed
+                swapData: SwapData({
+                    swapType: SwapType.NONE,
+                    extRouter: address(0),
+                    extCalldata: "",
+                    needScale: false
+                })
+            });
+    }
+
+    /**
+     * @dev Internal safe function to make sure the contract you want to
+     *   interact with has enough allowance to pull the desired tokens.
+     * @param _contract The address of the contract that will move the token.
+     * @param _token The ERC-20 token that will be getting spent.
+     * @param _amount The amount of `_token` to be spent.
+     */
+    function _checkAllowance(
+        address _contract,
+        address _token,
+        uint256 _amount
+    ) internal virtual {
+        if (ERC20(_token).allowance(address(this), _contract) < _amount) {
+            ERC20(_token).forceApprove(_contract, _amount);
+        }
+    }
+}

--- a/src/swappers/PendleSwapper.sol
+++ b/src/swappers/PendleSwapper.sol
@@ -5,18 +5,7 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {BaseSwapper} from "./BaseSwapper.sol";
-import {
-    IPendleRouter,
-    IPMarket,
-    IPYieldToken,
-    ApproxParams,
-    TokenInput,
-    TokenOutput,
-    SwapData,
-    SwapType,
-    LimitOrderData,
-    FillOrderParams
-} from "../interfaces/Pendle/IPendle.sol";
+import {IPendleRouter, IPMarket, IPYieldToken, ApproxParams, TokenInput, TokenOutput, SwapData, SwapType, LimitOrderData, FillOrderParams} from "../interfaces/Pendle/IPendle.sol";
 
 /**
  * @title PendleSwapper
@@ -113,14 +102,15 @@ contract PendleSwapper is BaseSwapper {
     ) internal virtual returns (uint256 _amountOut) {
         _checkAllowance(pendleRouter, _tokenIn, _amountIn);
 
-        (uint256 netPtOut, , ) = IPendleRouter(pendleRouter).swapExactTokenForPt(
-            address(this),
-            _market,
-            _minPtOut,
-            _getDefaultApproxParams(),
-            _getSimpleTokenInput(_tokenIn, _amountIn),
-            _getEmptyLimitOrderData()
-        );
+        (uint256 netPtOut, , ) = IPendleRouter(pendleRouter)
+            .swapExactTokenForPt(
+                address(this),
+                _market,
+                _minPtOut,
+                _getDefaultApproxParams(),
+                _getSimpleTokenInput(_tokenIn, _amountIn),
+                _getEmptyLimitOrderData()
+            );
 
         _amountOut = netPtOut;
     }
@@ -143,13 +133,14 @@ contract PendleSwapper is BaseSwapper {
     ) internal virtual returns (uint256 _amountOut) {
         _checkAllowance(pendleRouter, _pt, _amountIn);
 
-        (uint256 netTokenOut, , ) = IPendleRouter(pendleRouter).swapExactPtForToken(
-            address(this),
-            _market,
-            _amountIn,
-            _getSimpleTokenOutput(_tokenOut, _minTokenOut),
-            _getEmptyLimitOrderData()
-        );
+        (uint256 netTokenOut, , ) = IPendleRouter(pendleRouter)
+            .swapExactPtForToken(
+                address(this),
+                _market,
+                _amountIn,
+                _getSimpleTokenOutput(_tokenOut, _minTokenOut),
+                _getEmptyLimitOrderData()
+            );
 
         _amountOut = netTokenOut;
     }

--- a/src/swappers/PendleSwapperWithAggregator.sol
+++ b/src/swappers/PendleSwapperWithAggregator.sol
@@ -5,14 +5,7 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {PendleSwapper} from "./PendleSwapper.sol";
-import {
-    IPendleRouter,
-    IPMarket,
-    IPYieldToken,
-    TokenInput,
-    TokenOutput,
-    SwapData
-} from "../interfaces/Pendle/IPendle.sol";
+import {IPendleRouter, IPMarket, IPYieldToken, TokenInput, TokenOutput, SwapData} from "../interfaces/Pendle/IPendle.sol";
 
 /**
  * @title PendleSwapperWithAggregator
@@ -67,14 +60,15 @@ contract PendleSwapperWithAggregator is PendleSwapper {
             swapData: _swapData
         });
 
-        (uint256 netPtOut, , ) = IPendleRouter(pendleRouter).swapExactTokenForPt(
-            address(this),
-            market,
-            _minPtOut,
-            _getDefaultApproxParams(),
-            input,
-            _getEmptyLimitOrderData()
-        );
+        (uint256 netPtOut, , ) = IPendleRouter(pendleRouter)
+            .swapExactTokenForPt(
+                address(this),
+                market,
+                _minPtOut,
+                _getDefaultApproxParams(),
+                input,
+                _getEmptyLimitOrderData()
+            );
 
         _amountOut = netPtOut;
     }
@@ -118,12 +112,8 @@ contract PendleSwapperWithAggregator is PendleSwapper {
         if (IPMarket(market).isExpired()) {
             (, , IPYieldToken YT) = IPMarket(market).readTokens();
 
-            (uint256 netTokenOut, ) = IPendleRouter(pendleRouter).redeemPyToToken(
-                address(this),
-                address(YT),
-                _amountIn,
-                output
-            );
+            (uint256 netTokenOut, ) = IPendleRouter(pendleRouter)
+                .redeemPyToToken(address(this), address(YT), _amountIn, output);
             _amountOut = netTokenOut;
         } else {
             (uint256 netTokenOut, , ) = IPendleRouter(pendleRouter)

--- a/src/swappers/PendleSwapperWithAggregator.sol
+++ b/src/swappers/PendleSwapperWithAggregator.sol
@@ -65,7 +65,7 @@ contract PendleSwapperWithAggregator is PendleSwapper {
                 address(this),
                 market,
                 _minPtOut,
-                _getDefaultApproxParams(),
+                _getDefaultApproxParams(_amountIn),
                 input,
                 _getEmptyLimitOrderData()
             );

--- a/src/swappers/PendleSwapperWithAggregator.sol
+++ b/src/swappers/PendleSwapperWithAggregator.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.18;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {PendleSwapper} from "./PendleSwapper.sol";
+import {
+    IPendleRouter,
+    IPMarket,
+    IPYieldToken,
+    TokenInput,
+    TokenOutput,
+    SwapData
+} from "../interfaces/Pendle/IPendle.sol";
+
+/**
+ * @title PendleSwapperWithAggregator
+ * @author yearn.fi
+ * @dev Extension of PendleSwapper that allows swapping from arbitrary tokens
+ *   by using an external swap aggregator (e.g., 1inch, Kyberswap) to first
+ *   convert the input token to a token that the SY contract accepts.
+ *
+ *   This is useful when your strategy holds a token that is not directly
+ *   accepted by the SY contract for minting.
+ *
+ *   Example flow for buying PT with USDC when SY only accepts stETH:
+ *   1. USDC -> stETH (via aggregator specified in SwapData)
+ *   2. stETH -> SY -> PT (via Pendle router)
+ */
+contract PendleSwapperWithAggregator is PendleSwapper {
+    using SafeERC20 for ERC20;
+
+    /**
+     * @dev Buy PT tokens using an external aggregator to first swap the input token.
+     *
+     * @param _tokenIn The input token (can be any token).
+     * @param _pt The PT token to buy (must be registered in markets).
+     * @param _amountIn Amount of input token to spend.
+     * @param _minPtOut Minimum PT to receive.
+     * @param _tokenMintSy The token that SY accepts for minting (e.g., stETH).
+     * @param _swapData Aggregator swap data for tokenIn -> tokenMintSy conversion.
+     * @return _amountOut Amount of PT received.
+     */
+    function _swapFromWithAggregator(
+        address _tokenIn,
+        address _pt,
+        uint256 _amountIn,
+        uint256 _minPtOut,
+        address _tokenMintSy,
+        SwapData calldata _swapData
+    ) internal virtual returns (uint256 _amountOut) {
+        if (_amountIn == 0 || _amountIn < minAmountToSell) {
+            return 0;
+        }
+
+        address market = markets[_pt];
+        require(market != address(0), "PendleSwapper: unknown market");
+
+        _checkAllowance(pendleRouter, _tokenIn, _amountIn);
+
+        TokenInput memory input = TokenInput({
+            tokenIn: _tokenIn,
+            netTokenIn: _amountIn,
+            tokenMintSy: _tokenMintSy,
+            pendleSwap: _swapData.extRouter,
+            swapData: _swapData
+        });
+
+        (uint256 netPtOut, , ) = IPendleRouter(pendleRouter).swapExactTokenForPt(
+            address(this),
+            market,
+            _minPtOut,
+            _getDefaultApproxParams(),
+            input,
+            _getEmptyLimitOrderData()
+        );
+
+        _amountOut = netPtOut;
+    }
+
+    /**
+     * @dev Sell PT tokens and convert output via an external aggregator.
+     *
+     * @param _pt The PT token to sell (must be registered in markets).
+     * @param _tokenOut The final output token (can be any token).
+     * @param _amountIn Amount of PT to sell.
+     * @param _minTokenOut Minimum output token to receive.
+     * @param _tokenRedeemSy The token that SY redeems to (e.g., stETH).
+     * @param _swapData Aggregator swap data for tokenRedeemSy -> tokenOut conversion.
+     * @return _amountOut Amount of output token received.
+     */
+    function _swapToWithAggregator(
+        address _pt,
+        address _tokenOut,
+        uint256 _amountIn,
+        uint256 _minTokenOut,
+        address _tokenRedeemSy,
+        SwapData calldata _swapData
+    ) internal virtual returns (uint256 _amountOut) {
+        if (_amountIn == 0 || _amountIn < minAmountToSell) {
+            return 0;
+        }
+
+        address market = markets[_pt];
+        require(market != address(0), "PendleSwapper: unknown market");
+
+        _checkAllowance(pendleRouter, _pt, _amountIn);
+
+        TokenOutput memory output = TokenOutput({
+            tokenOut: _tokenOut,
+            minTokenOut: _minTokenOut,
+            tokenRedeemSy: _tokenRedeemSy,
+            pendleSwap: _swapData.extRouter,
+            swapData: _swapData
+        });
+
+        if (IPMarket(market).isExpired()) {
+            (, , IPYieldToken YT) = IPMarket(market).readTokens();
+
+            (uint256 netTokenOut, ) = IPendleRouter(pendleRouter).redeemPyToToken(
+                address(this),
+                address(YT),
+                _amountIn,
+                output
+            );
+            _amountOut = netTokenOut;
+        } else {
+            (uint256 netTokenOut, , ) = IPendleRouter(pendleRouter)
+                .swapExactPtForToken(
+                    address(this),
+                    market,
+                    _amountIn,
+                    output,
+                    _getEmptyLimitOrderData()
+                );
+            _amountOut = netTokenOut;
+        }
+    }
+}

--- a/src/swappers/interfaces/IPendleSwapper.sol
+++ b/src/swappers/interfaces/IPendleSwapper.sol
@@ -7,4 +7,6 @@ interface IPendleSwapper is IBaseSwapper {
     function pendleRouter() external view returns (address);
 
     function markets(address pt) external view returns (address market);
+
+    function guessMaxMultiplier() external view returns (uint256);
 }

--- a/src/swappers/interfaces/IPendleSwapper.sol
+++ b/src/swappers/interfaces/IPendleSwapper.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.18;
+
+import "./IBaseSwapper.sol";
+
+interface IPendleSwapper is IBaseSwapper {
+    function pendleRouter() external view returns (address);
+
+    function markets(address pt) external view returns (address market);
+}

--- a/src/test/PendleSwapper.t.sol
+++ b/src/test/PendleSwapper.t.sol
@@ -90,7 +90,7 @@ contract PendleSwapperTest is Setup {
         mockAsset.mint(address(pendleSwapper), amount);
 
         // Swap should return 0 when amount is below minAmountToSell
-        uint256 amountOut = pendleSwapper.swapFrom(
+        uint256 amountOut = pendleSwapper.pendleSwapFrom(
             address(mockAsset),
             address(0x9999),
             amount,
@@ -110,7 +110,7 @@ contract PendleSwapperTest is Setup {
 
         // Try to swap to an unknown token (no market registered)
         vm.expectRevert("PendleSwapper: unknown market");
-        pendleSwapper.swapFrom(address(mockAsset), unknownToken, amount, 0);
+        pendleSwapper.pendleSwapFrom(address(mockAsset), unknownToken, amount, 0);
     }
 
     function test_zeroAmount_returns_zero() public {
@@ -119,7 +119,7 @@ contract PendleSwapperTest is Setup {
         pendleSwapper.setMarket(MOCK_PT, MOCK_MARKET);
 
         // Swap with 0 amount should return 0
-        uint256 amountOut = pendleSwapper.swapFrom(
+        uint256 amountOut = pendleSwapper.pendleSwapFrom(
             address(mockAsset),
             MOCK_PT,
             0,

--- a/src/test/PendleSwapper.t.sol
+++ b/src/test/PendleSwapper.t.sol
@@ -110,7 +110,12 @@ contract PendleSwapperTest is Setup {
 
         // Try to swap to an unknown token (no market registered)
         vm.expectRevert("PendleSwapper: unknown market");
-        pendleSwapper.pendleSwapFrom(address(mockAsset), unknownToken, amount, 0);
+        pendleSwapper.pendleSwapFrom(
+            address(mockAsset),
+            unknownToken,
+            amount,
+            0
+        );
     }
 
     function test_zeroAmount_returns_zero() public {

--- a/src/test/PendleSwapper.t.sol
+++ b/src/test/PendleSwapper.t.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.18;
+
+import {Setup, ERC20, IStrategy} from "./utils/Setup.sol";
+
+import {MockPendleSwapper, IMockPendleSwapper} from "./mocks/MockPendleSwapper.sol";
+import {IPMarket} from "../interfaces/Pendle/IPendle.sol";
+
+import {MockToken} from "./mocks/MockToken.sol";
+
+/**
+ * @title PendleSwapperTest
+ * @notice Unit tests for the PendleSwapper contract
+ * @dev These tests verify the swapper logic without requiring mainnet fork.
+ *   For full integration tests, use a mainnet fork with a currently active Pendle market.
+ */
+contract PendleSwapperTest is Setup {
+    IMockPendleSwapper public pendleSwapper;
+
+    MockToken public mockAsset;
+
+    // Pendle Router V4
+    address public constant PENDLE_ROUTER =
+        0x888888888889758F76e7103c6CbF23ABbF58F946;
+
+    // Mock addresses for unit tests
+    address public constant MOCK_MARKET = address(0x1111);
+    address public constant MOCK_PT = address(0x2222);
+    address public constant MOCK_UNDERLYING = address(0x3333);
+
+    function setUp() public override {
+        // Deploy mock token for testing
+        mockAsset = new MockToken("Mock Asset", "MOCK", 18);
+
+        // Deploy mock pendle swapper with the mock asset
+        pendleSwapper = IMockPendleSwapper(
+            address(new MockPendleSwapper(address(mockAsset)))
+        );
+
+        pendleSwapper.setKeeper(keeper);
+        pendleSwapper.setPerformanceFeeRecipient(performanceFeeRecipient);
+        pendleSwapper.setPendingManagement(management);
+        vm.prank(management);
+        pendleSwapper.acceptManagement();
+    }
+
+    function test_setMarket() public {
+        address pt = address(0x1111);
+        address market = address(0x2222);
+
+        assertEq(pendleSwapper.markets(pt), address(0));
+
+        vm.prank(management);
+        pendleSwapper.setMarket(pt, market);
+
+        assertEq(pendleSwapper.markets(pt), market);
+    }
+
+    function test_multipleMarkets() public {
+        address pt1 = address(0x1111);
+        address market1 = address(0x2222);
+        address pt2 = address(0x3333);
+        address market2 = address(0x4444);
+
+        vm.prank(management);
+        pendleSwapper.setMarket(pt1, market1);
+
+        vm.prank(management);
+        pendleSwapper.setMarket(pt2, market2);
+
+        // Verify both markets are registered
+        assertEq(pendleSwapper.markets(pt1), market1);
+        assertEq(pendleSwapper.markets(pt2), market2);
+    }
+
+    function test_minAmountToSell() public {
+        // Set a market so swap detection works
+        vm.prank(management);
+        pendleSwapper.setMarket(address(0x9999), MOCK_MARKET);
+
+        uint256 amount = 1e15;
+
+        // Set min amount to sell higher than our amount
+        vm.prank(management);
+        pendleSwapper.setMinAmountToSell(1e16);
+
+        assertEq(pendleSwapper.minAmountToSell(), 1e16);
+
+        // Mint tokens to the swapper
+        mockAsset.mint(address(pendleSwapper), amount);
+
+        // Swap should return 0 when amount is below minAmountToSell
+        uint256 amountOut = pendleSwapper.swapFrom(
+            address(mockAsset),
+            address(0x9999),
+            amount,
+            0
+        );
+
+        // Should not have swapped
+        assertEq(amountOut, 0);
+        assertEq(mockAsset.balanceOf(address(pendleSwapper)), amount);
+    }
+
+    function test_unknownMarket_reverts() public {
+        address unknownToken = address(0xdead);
+
+        uint256 amount = 1e18;
+        mockAsset.mint(address(pendleSwapper), amount);
+
+        // Try to swap to an unknown token (no market registered)
+        vm.expectRevert("PendleSwapper: unknown market");
+        pendleSwapper.swapFrom(address(mockAsset), unknownToken, amount, 0);
+    }
+
+    function test_zeroAmount_returns_zero() public {
+        // Set a market so swap detection works
+        vm.prank(management);
+        pendleSwapper.setMarket(MOCK_PT, MOCK_MARKET);
+
+        // Swap with 0 amount should return 0
+        uint256 amountOut = pendleSwapper.swapFrom(
+            address(mockAsset),
+            MOCK_PT,
+            0,
+            0
+        );
+
+        assertEq(amountOut, 0);
+    }
+
+    function test_defaultPendleRouter() public {
+        // Verify default router is set correctly
+        assertEq(pendleSwapper.pendleRouter(), PENDLE_ROUTER);
+    }
+
+    function test_defaultMinAmountToSell() public {
+        // Verify default minAmountToSell is 0
+        assertEq(pendleSwapper.minAmountToSell(), 0);
+    }
+}
+
+/**
+ * @title PendleSwapperForkTest
+ * @notice Fork tests for the PendleSwapper contract
+ * @dev These tests require a mainnet fork with ETH_RPC_URL set.
+ *   Run with: forge test --match-contract PendleSwapperForkTest --fork-url $ETH_RPC_URL
+ *
+ *   Note: The specific market addresses and block numbers may need to be updated
+ *   as Pendle markets expire. Find active markets at https://app.pendle.finance/
+ */
+contract PendleSwapperForkTest is Setup {
+    // Skip fork tests if ETH_RPC_URL is not set
+    // To run: forge test --match-contract PendleSwapperForkTest --fork-url $ETH_RPC_URL
+}

--- a/src/test/PendleSwapper.t.sol
+++ b/src/test/PendleSwapper.t.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.18;
 import {Setup, ERC20, IStrategy} from "./utils/Setup.sol";
 
 import {MockPendleSwapper, IMockPendleSwapper} from "./mocks/MockPendleSwapper.sol";
-import {IPMarket} from "../interfaces/Pendle/IPendle.sol";
+import {IPMarket, IPPrincipalToken} from "../interfaces/Pendle/IPendle.sol";
 
 import {MockToken} from "./mocks/MockToken.sol";
 
@@ -168,6 +168,514 @@ contract PendleSwapperTest is Setup {
  *   as Pendle markets expire. Find active markets at https://app.pendle.finance/
  */
 contract PendleSwapperForkTest is Setup {
-    // Skip fork tests if ETH_RPC_URL is not set
-    // To run: forge test --match-contract PendleSwapperForkTest --fork-url $ETH_RPC_URL
+    IMockPendleSwapper public pendleSwapper;
+
+    // USDC token on mainnet
+    ERC20 public usdc;
+    address public constant USDC_ADDRESS =
+        0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+
+    // Pendle market for USDC PT
+    address public constant PENDLE_MARKET =
+        0x307c15f808914Df5a5DbE17E5608f84953fFa023;
+
+    // Pendle Router V4
+    address public constant PENDLE_ROUTER =
+        0x888888888889758F76e7103c6CbF23ABbF58F946;
+
+    // PT token address - will be fetched from market
+    address public pt;
+
+    // Fuzz amounts for USDC (6 decimals)
+    uint256 public minUsdcAmount = 100e6; // 100 USDC
+    uint256 public maxUsdcAmount = 100_000e6; // 100,000 USDC
+
+    function setUp() public override {
+        usdc = ERC20(USDC_ADDRESS);
+
+        // Get PT address from market
+        (, IPPrincipalToken _PT, ) = IPMarket(PENDLE_MARKET).readTokens();
+        pt = address(_PT);
+
+        // Deploy mock pendle swapper with USDC as asset
+        pendleSwapper = IMockPendleSwapper(
+            address(new MockPendleSwapper(USDC_ADDRESS))
+        );
+
+        pendleSwapper.setKeeper(keeper);
+        pendleSwapper.setPerformanceFeeRecipient(performanceFeeRecipient);
+        pendleSwapper.setPendingManagement(management);
+        vm.prank(management);
+        pendleSwapper.acceptManagement();
+
+        // Register the PT market
+        vm.prank(management);
+        pendleSwapper.setMarket(pt, PENDLE_MARKET);
+
+        // Label addresses for better trace output
+        vm.label(USDC_ADDRESS, "USDC");
+        vm.label(PENDLE_MARKET, "PendleMarket");
+        vm.label(PENDLE_ROUTER, "PendleRouter");
+        vm.label(pt, "PT");
+    }
+
+    function test_fork_buyPt(uint256 amount) public {
+        vm.assume(amount >= minUsdcAmount && amount <= maxUsdcAmount);
+
+        // Airdrop USDC to the swapper
+        airdrop(usdc, address(pendleSwapper), amount);
+
+        // Record balances before swap
+        uint256 usdcBefore = usdc.balanceOf(address(pendleSwapper));
+        uint256 ptBefore = ERC20(pt).balanceOf(address(pendleSwapper));
+
+        assertEq(
+            usdcBefore,
+            amount,
+            "USDC balance should equal airdropped amount"
+        );
+        assertEq(ptBefore, 0, "PT balance should be 0 before swap");
+
+        // Swap USDC to PT (buying PT)
+        uint256 amountOut = pendleSwapper.pendleSwapFrom(
+            USDC_ADDRESS,
+            pt,
+            amount,
+            0 // No minimum for test
+        );
+
+        // Verify swap results
+        uint256 usdcAfter = usdc.balanceOf(address(pendleSwapper));
+        uint256 ptAfter = ERC20(pt).balanceOf(address(pendleSwapper));
+
+        assertEq(usdcAfter, 0, "USDC should be fully spent");
+        assertGt(ptAfter, 0, "Should have received PT");
+        assertEq(ptAfter, amountOut, "PT balance should match return value");
+    }
+
+    function test_fork_sellPt(uint256 amount) public {
+        vm.assume(amount >= minUsdcAmount && amount <= maxUsdcAmount);
+
+        // Skip if market is expired (can't sell via AMM after expiry)
+        if (IPMarket(PENDLE_MARKET).isExpired()) {
+            return;
+        }
+
+        // First buy some PT
+        airdrop(usdc, address(pendleSwapper), amount);
+        uint256 ptAmount = pendleSwapper.pendleSwapFrom(
+            USDC_ADDRESS,
+            pt,
+            amount,
+            0
+        );
+
+        // Record balances before selling
+        uint256 usdcBefore = usdc.balanceOf(address(pendleSwapper));
+        uint256 ptBefore = ERC20(pt).balanceOf(address(pendleSwapper));
+
+        assertEq(usdcBefore, 0, "USDC balance should be 0 before sell");
+        assertEq(ptBefore, ptAmount, "PT balance should equal bought amount");
+
+        // Sell PT back to USDC
+        uint256 amountOut = pendleSwapper.pendleSwapFrom(
+            pt,
+            USDC_ADDRESS,
+            ptAmount,
+            0 // No minimum for test
+        );
+
+        // Verify sell results
+        uint256 usdcAfter = usdc.balanceOf(address(pendleSwapper));
+        uint256 ptAfter = ERC20(pt).balanceOf(address(pendleSwapper));
+
+        assertEq(ptAfter, 0, "PT should be fully sold");
+        assertGt(usdcAfter, 0, "Should have received USDC");
+        assertEq(
+            usdcAfter,
+            amountOut,
+            "USDC balance should match return value"
+        );
+    }
+
+    function test_fork_buyPt_withMinAmountOut() public {
+        uint256 amount = 10_000e6; // 10,000 USDC
+
+        // Airdrop USDC to the swapper
+        airdrop(usdc, address(pendleSwapper), amount);
+
+        // Set an unreasonably high minAmountOut that should cause revert
+        uint256 unreasonableMin = amount * 1e18; // Way more PT than possible
+
+        vm.expectRevert();
+        pendleSwapper.pendleSwapFrom(USDC_ADDRESS, pt, amount, unreasonableMin);
+
+        // Verify no swap occurred
+        assertEq(
+            usdc.balanceOf(address(pendleSwapper)),
+            amount,
+            "USDC should not be spent"
+        );
+        assertEq(
+            ERC20(pt).balanceOf(address(pendleSwapper)),
+            0,
+            "Should not have PT"
+        );
+    }
+
+    function test_fork_sellPt_withMinAmountOut() public {
+        // Skip if market is expired
+        if (IPMarket(PENDLE_MARKET).isExpired()) {
+            return;
+        }
+
+        uint256 amount = 10_000e6; // 10,000 USDC
+
+        // First buy some PT
+        airdrop(usdc, address(pendleSwapper), amount);
+        uint256 ptAmount = pendleSwapper.pendleSwapFrom(
+            USDC_ADDRESS,
+            pt,
+            amount,
+            0
+        );
+
+        // Set an unreasonably high minAmountOut
+        uint256 unreasonableMin = amount * 1e18;
+
+        vm.expectRevert();
+        pendleSwapper.pendleSwapFrom(
+            pt,
+            USDC_ADDRESS,
+            ptAmount,
+            unreasonableMin
+        );
+
+        // Verify no swap occurred
+        assertEq(
+            ERC20(pt).balanceOf(address(pendleSwapper)),
+            ptAmount,
+            "PT should not be spent"
+        );
+    }
+
+    function test_fork_marketConfiguration() public {
+        // Verify market is correctly registered
+        assertEq(
+            pendleSwapper.markets(pt),
+            PENDLE_MARKET,
+            "Market should be registered"
+        );
+
+        // Verify PT is not expired for active trading tests
+        (, IPPrincipalToken _PT, ) = IPMarket(PENDLE_MARKET).readTokens();
+
+        // Log expiry for debugging
+        uint256 expiry = _PT.expiry();
+        emit log_named_uint("PT expiry timestamp", expiry);
+        emit log_named_uint("Current timestamp", block.timestamp);
+    }
+
+    function test_fork_guessMaxMultiplier(uint256 amount) public {
+        vm.assume(amount >= minUsdcAmount && amount <= maxUsdcAmount);
+
+        // Set a custom guessMaxMultiplier
+        vm.prank(management);
+        pendleSwapper.setGuessMaxMultiplier(2e18); // 2x multiplier
+
+        assertEq(
+            pendleSwapper.guessMaxMultiplier(),
+            2e18,
+            "Multiplier should be set"
+        );
+
+        // Airdrop USDC to the swapper
+        airdrop(usdc, address(pendleSwapper), amount);
+
+        // Swap should still work with custom multiplier
+        uint256 amountOut = pendleSwapper.pendleSwapFrom(
+            USDC_ADDRESS,
+            pt,
+            amount,
+            0
+        );
+
+        assertGt(amountOut, 0, "Swap should succeed with custom multiplier");
+        assertEq(
+            ERC20(pt).balanceOf(address(pendleSwapper)),
+            amountOut,
+            "Should have PT"
+        );
+    }
+
+    function test_fork_minAmountToSell() public {
+        uint256 amount = 1000e6; // 1000 USDC
+
+        // Set minAmountToSell higher than our swap amount
+        vm.prank(management);
+        pendleSwapper.setMinAmountToSell(2000e6); // 2000 USDC minimum
+
+        // Airdrop USDC to the swapper
+        airdrop(usdc, address(pendleSwapper), amount);
+
+        // Swap should return 0 and not execute because amount < minAmountToSell
+        uint256 amountOut = pendleSwapper.pendleSwapFrom(
+            USDC_ADDRESS,
+            pt,
+            amount,
+            0
+        );
+
+        assertEq(amountOut, 0, "Should return 0 when below minAmountToSell");
+        assertEq(
+            usdc.balanceOf(address(pendleSwapper)),
+            amount,
+            "USDC should not be spent"
+        );
+        assertEq(
+            ERC20(pt).balanceOf(address(pendleSwapper)),
+            0,
+            "Should not have PT"
+        );
+    }
+
+    function test_fork_roundTrip(uint256 amount) public {
+        vm.assume(amount >= minUsdcAmount && amount <= maxUsdcAmount);
+
+        // Skip if market is expired
+        if (IPMarket(PENDLE_MARKET).isExpired()) {
+            return;
+        }
+
+        // Airdrop USDC to the swapper
+        airdrop(usdc, address(pendleSwapper), amount);
+
+        // Buy PT
+        uint256 ptReceived = pendleSwapper.pendleSwapFrom(
+            USDC_ADDRESS,
+            pt,
+            amount,
+            0
+        );
+
+        assertGt(ptReceived, 0, "Should receive PT");
+
+        // Sell PT back to USDC
+        uint256 usdcReceived = pendleSwapper.pendleSwapFrom(
+            pt,
+            USDC_ADDRESS,
+            ptReceived,
+            0
+        );
+
+        assertGt(usdcReceived, 0, "Should receive USDC back");
+
+        // Due to AMM fees and slippage, we expect some loss
+        // The received amount should be less than original but reasonably close
+        assertLt(usdcReceived, amount, "Should have some slippage loss");
+        assertGt(
+            usdcReceived,
+            (amount * 90) / 100,
+            "Should not lose more than 10%"
+        );
+    }
+
+    function test_fork_multipleSwaps() public {
+        // Skip if market is expired
+        if (IPMarket(PENDLE_MARKET).isExpired()) {
+            return;
+        }
+
+        uint256 amount1 = 5_000e6;
+        uint256 amount2 = 10_000e6;
+        uint256 amount3 = 15_000e6;
+
+        // First swap
+        airdrop(usdc, address(pendleSwapper), amount1);
+        uint256 pt1 = pendleSwapper.pendleSwapFrom(
+            USDC_ADDRESS,
+            pt,
+            amount1,
+            0
+        );
+        assertGt(pt1, 0, "First swap should succeed");
+
+        // Second swap
+        airdrop(usdc, address(pendleSwapper), amount2);
+        uint256 pt2 = pendleSwapper.pendleSwapFrom(
+            USDC_ADDRESS,
+            pt,
+            amount2,
+            0
+        );
+        assertGt(pt2, 0, "Second swap should succeed");
+
+        // Third swap
+        airdrop(usdc, address(pendleSwapper), amount3);
+        uint256 pt3 = pendleSwapper.pendleSwapFrom(
+            USDC_ADDRESS,
+            pt,
+            amount3,
+            0
+        );
+        assertGt(pt3, 0, "Third swap should succeed");
+
+        // Total PT should be sum of all swaps
+        uint256 totalPt = ERC20(pt).balanceOf(address(pendleSwapper));
+        assertEq(totalPt, pt1 + pt2 + pt3, "Total PT should be sum of swaps");
+
+        // Sell all PT at once
+        uint256 usdcBack = pendleSwapper.pendleSwapFrom(
+            pt,
+            USDC_ADDRESS,
+            totalPt,
+            0
+        );
+        assertGt(usdcBack, 0, "Should receive USDC back");
+    }
+
+    function test_fork_pendleRouterAddress() public {
+        assertEq(
+            pendleSwapper.pendleRouter(),
+            PENDLE_ROUTER,
+            "Pendle router should be correctly set"
+        );
+    }
+
+    // Chainlink USDC/USD price feed on mainnet
+    address public constant CHAINLINK_USDC_USD =
+        0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6;
+
+    /**
+     * @dev Helper to mock Chainlink price feeds after time warp.
+     *   The underlying CapToken uses Oracle price feeds with staleness checks.
+     *   After warping to expiry, we need to mock the feeds to return valid timestamps.
+     */
+    function _mockChainlinkAfterWarp() internal {
+        // Mock the USDC/USD Chainlink feed to return valid data at current block.timestamp
+        // latestRoundData returns (roundId, answer, startedAt, updatedAt, answeredInRound)
+        vm.mockCall(
+            CHAINLINK_USDC_USD,
+            abi.encodeWithSignature("latestRoundData()"),
+            abi.encode(
+                uint80(1000), // roundId
+                int256(100000000), // answer: $1.00 with 8 decimals
+                block.timestamp - 1, // startedAt
+                block.timestamp - 1, // updatedAt (recent)
+                uint80(1000) // answeredInRound
+            )
+        );
+    }
+
+    function test_fork_redeemPtAfterExpiry(uint256 amount) public {
+        vm.assume(amount >= minUsdcAmount && amount <= maxUsdcAmount);
+
+        // Buy PT before expiry
+        airdrop(usdc, address(pendleSwapper), amount);
+        uint256 ptReceived = pendleSwapper.pendleSwapFrom(
+            USDC_ADDRESS,
+            pt,
+            amount,
+            0
+        );
+
+        assertGt(ptReceived, 0, "Should receive PT");
+
+        // Get PT expiry and warp past it
+        (, IPPrincipalToken _PT, ) = IPMarket(PENDLE_MARKET).readTokens();
+        uint256 expiry = _PT.expiry();
+
+        // Warp to after expiry
+        vm.warp(expiry + 1);
+
+        // Mock Chainlink feed after warp to avoid staleness errors in underlying CapToken
+        _mockChainlinkAfterWarp();
+
+        // Verify market is now expired
+        assertTrue(
+            IPMarket(PENDLE_MARKET).isExpired(),
+            "Market should be expired"
+        );
+
+        // Record PT balance before redemption
+        uint256 ptBefore = ERC20(pt).balanceOf(address(pendleSwapper));
+        assertEq(ptBefore, ptReceived, "PT balance should match");
+
+        // Redeem PT after expiry - should call redeemPyToToken
+        uint256 usdcReceived = pendleSwapper.pendleSwapFrom(
+            pt,
+            USDC_ADDRESS,
+            ptReceived,
+            0
+        );
+
+        // Verify redemption results
+        uint256 ptAfter = ERC20(pt).balanceOf(address(pendleSwapper));
+        uint256 usdcAfter = usdc.balanceOf(address(pendleSwapper));
+
+        assertEq(ptAfter, 0, "All PT should be redeemed");
+        assertGt(usdcReceived, 0, "Should receive USDC from redemption");
+        assertEq(
+            usdcAfter,
+            usdcReceived,
+            "USDC balance should match return value"
+        );
+
+        // After expiry, PT redeems 1:1 with underlying value
+        // We should get back approximately the original amount (within 1% for rounding)
+        // PT at expiry = 1 unit of underlying value
+        assertGe(
+            usdcReceived,
+            (amount * 99) / 100,
+            "Should receive at least 99% of original amount after expiry redemption"
+        );
+    }
+
+    function test_fork_redeemPtAfterExpiry_exactValue() public {
+        uint256 amount = 10_000e6; // 10,000 USDC
+
+        // Buy PT before expiry
+        airdrop(usdc, address(pendleSwapper), amount);
+        uint256 ptReceived = pendleSwapper.pendleSwapFrom(
+            USDC_ADDRESS,
+            pt,
+            amount,
+            0
+        );
+
+        // Get PT expiry and warp past it
+        (, IPPrincipalToken _PT, ) = IPMarket(PENDLE_MARKET).readTokens();
+        uint256 expiry = _PT.expiry();
+        vm.warp(expiry + 1);
+
+        // Mock Chainlink feed after warp to avoid staleness errors in underlying CapToken
+        _mockChainlinkAfterWarp();
+
+        // Redeem PT after expiry
+        uint256 usdcReceived = pendleSwapper.pendleSwapFrom(
+            pt,
+            USDC_ADDRESS,
+            ptReceived,
+            0
+        );
+
+        // Log values for debugging
+        emit log_named_uint("Original USDC amount", amount);
+        emit log_named_uint("PT received from swap", ptReceived);
+        emit log_named_uint("USDC received from redemption", usdcReceived);
+        emit log_named_uint(
+            "Difference",
+            usdcReceived > amount
+                ? usdcReceived - amount
+                : amount - usdcReceived
+        );
+
+        // PT should redeem for full underlying value at expiry
+        // The slight gain is due to buying PT at a discount (implied yield)
+        assertGe(
+            usdcReceived,
+            amount,
+            "Should receive at least original amount at expiry"
+        );
+    }
 }

--- a/src/test/PendleSwapper.t.sol
+++ b/src/test/PendleSwapper.t.sol
@@ -143,6 +143,19 @@ contract PendleSwapperTest is Setup {
         // Verify default minAmountToSell is 0
         assertEq(pendleSwapper.minAmountToSell(), 0);
     }
+
+    function test_defaultGuessMaxMultiplier() public {
+        // Verify default guessMaxMultiplier is 0 (uses type(uint256).max)
+        assertEq(pendleSwapper.guessMaxMultiplier(), 0);
+    }
+
+    function test_setGuessMaxMultiplier() public {
+        // Set multiplier
+        vm.prank(management);
+        pendleSwapper.setGuessMaxMultiplier(1e14);
+
+        assertEq(pendleSwapper.guessMaxMultiplier(), 1e14);
+    }
 }
 
 /**

--- a/src/test/mocks/MockPendleSwapper.sol
+++ b/src/test/mocks/MockPendleSwapper.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.18;
+
+import {PendleSwapper} from "../../swappers/PendleSwapper.sol";
+import {PendleSwapperWithAggregator} from "../../swappers/PendleSwapperWithAggregator.sol";
+import {SwapData} from "../../interfaces/Pendle/IPendle.sol";
+import {BaseStrategy, ERC20} from "@tokenized-strategy/BaseStrategy.sol";
+
+contract MockPendleSwapper is BaseStrategy, PendleSwapper {
+    constructor(address _asset) BaseStrategy(_asset, "Mock Pendle Swapper") {}
+
+    function _deployFunds(uint256) internal override {}
+
+    function _freeFunds(uint256) internal override {}
+
+    function _harvestAndReport()
+        internal
+        override
+        returns (uint256 _totalAssets)
+    {
+        _totalAssets = asset.balanceOf(address(this));
+    }
+
+    function setMinAmountToSell(uint256 _minAmountToSell) external {
+        minAmountToSell = _minAmountToSell;
+    }
+
+    function setMarket(address _pt, address _market) external {
+        _setMarket(_pt, _market);
+    }
+
+    function swapFrom(
+        address _from,
+        address _to,
+        uint256 _amountIn,
+        uint256 _minAmountOut
+    ) external returns (uint256) {
+        return _swapFrom(_from, _to, _amountIn, _minAmountOut);
+    }
+}
+
+contract MockPendleSwapperWithAggregator is
+    BaseStrategy,
+    PendleSwapperWithAggregator
+{
+    constructor(
+        address _asset
+    ) BaseStrategy(_asset, "Mock Pendle Swapper With Aggregator") {}
+
+    function _deployFunds(uint256) internal override {}
+
+    function _freeFunds(uint256) internal override {}
+
+    function _harvestAndReport()
+        internal
+        override
+        returns (uint256 _totalAssets)
+    {
+        _totalAssets = asset.balanceOf(address(this));
+    }
+
+    function setMinAmountToSell(uint256 _minAmountToSell) external {
+        minAmountToSell = _minAmountToSell;
+    }
+
+    function setMarket(address _pt, address _market) external {
+        _setMarket(_pt, _market);
+    }
+
+    function swapFrom(
+        address _from,
+        address _to,
+        uint256 _amountIn,
+        uint256 _minAmountOut
+    ) external returns (uint256) {
+        return _swapFrom(_from, _to, _amountIn, _minAmountOut);
+    }
+
+    function swapFromWithAggregator(
+        address _tokenIn,
+        address _pt,
+        uint256 _amountIn,
+        uint256 _minPtOut,
+        address _tokenMintSy,
+        SwapData calldata _swapData
+    ) external returns (uint256) {
+        return
+            _swapFromWithAggregator(
+                _tokenIn,
+                _pt,
+                _amountIn,
+                _minPtOut,
+                _tokenMintSy,
+                _swapData
+            );
+    }
+
+    function swapToWithAggregator(
+        address _pt,
+        address _tokenOut,
+        uint256 _amountIn,
+        uint256 _minTokenOut,
+        address _tokenRedeemSy,
+        SwapData calldata _swapData
+    ) external returns (uint256) {
+        return
+            _swapToWithAggregator(
+                _pt,
+                _tokenOut,
+                _amountIn,
+                _minTokenOut,
+                _tokenRedeemSy,
+                _swapData
+            );
+    }
+}
+
+import {IStrategy} from "@tokenized-strategy/interfaces/IStrategy.sol";
+import {IPendleSwapper} from "../../swappers/interfaces/IPendleSwapper.sol";
+
+interface IMockPendleSwapper is IStrategy, IPendleSwapper {
+    function setMinAmountToSell(uint256 _minAmountToSell) external;
+
+    function setMarket(address _pt, address _market) external;
+
+    function swapFrom(
+        address _from,
+        address _to,
+        uint256 _amountIn,
+        uint256 _minAmountOut
+    ) external returns (uint256);
+}
+
+interface IMockPendleSwapperWithAggregator is IMockPendleSwapper {
+    function swapFromWithAggregator(
+        address _tokenIn,
+        address _pt,
+        uint256 _amountIn,
+        uint256 _minPtOut,
+        address _tokenMintSy,
+        SwapData calldata _swapData
+    ) external returns (uint256);
+
+    function swapToWithAggregator(
+        address _pt,
+        address _tokenOut,
+        uint256 _amountIn,
+        uint256 _minTokenOut,
+        address _tokenRedeemSy,
+        SwapData calldata _swapData
+    ) external returns (uint256);
+}

--- a/src/test/mocks/MockPendleSwapper.sol
+++ b/src/test/mocks/MockPendleSwapper.sol
@@ -29,13 +29,13 @@ contract MockPendleSwapper is BaseStrategy, PendleSwapper {
         _setMarket(_pt, _market);
     }
 
-    function swapFrom(
+    function pendleSwapFrom(
         address _from,
         address _to,
         uint256 _amountIn,
         uint256 _minAmountOut
     ) external returns (uint256) {
-        return _swapFrom(_from, _to, _amountIn, _minAmountOut);
+        return _pendleSwapFrom(_from, _to, _amountIn, _minAmountOut);
     }
 }
 
@@ -67,13 +67,13 @@ contract MockPendleSwapperWithAggregator is
         _setMarket(_pt, _market);
     }
 
-    function swapFrom(
+    function pendleSwapFrom(
         address _from,
         address _to,
         uint256 _amountIn,
         uint256 _minAmountOut
     ) external returns (uint256) {
-        return _swapFrom(_from, _to, _amountIn, _minAmountOut);
+        return _pendleSwapFrom(_from, _to, _amountIn, _minAmountOut);
     }
 
     function swapFromWithAggregator(
@@ -123,7 +123,7 @@ interface IMockPendleSwapper is IStrategy, IPendleSwapper {
 
     function setMarket(address _pt, address _market) external;
 
-    function swapFrom(
+    function pendleSwapFrom(
         address _from,
         address _to,
         uint256 _amountIn,

--- a/src/test/mocks/MockPendleSwapper.sol
+++ b/src/test/mocks/MockPendleSwapper.sol
@@ -29,6 +29,10 @@ contract MockPendleSwapper is BaseStrategy, PendleSwapper {
         _setMarket(_pt, _market);
     }
 
+    function setGuessMaxMultiplier(uint256 _multiplier) external {
+        _setGuessMaxMultiplier(_multiplier);
+    }
+
     function pendleSwapFrom(
         address _from,
         address _to,
@@ -65,6 +69,10 @@ contract MockPendleSwapperWithAggregator is
 
     function setMarket(address _pt, address _market) external {
         _setMarket(_pt, _market);
+    }
+
+    function setGuessMaxMultiplier(uint256 _multiplier) external {
+        _setGuessMaxMultiplier(_multiplier);
     }
 
     function pendleSwapFrom(
@@ -122,6 +130,8 @@ interface IMockPendleSwapper is IStrategy, IPendleSwapper {
     function setMinAmountToSell(uint256 _minAmountToSell) external;
 
     function setMarket(address _pt, address _market) external;
+
+    function setGuessMaxMultiplier(uint256 _multiplier) external;
 
     function pendleSwapFrom(
         address _from,

--- a/src/test/mocks/MockToken.sol
+++ b/src/test/mocks/MockToken.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.18;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockToken is ERC20 {
+    uint8 private _decimals;
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_
+    ) ERC20(name_, symbol_) {
+        _decimals = decimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function burn(address from, uint256 amount) external {
+        _burn(from, amount);
+    }
+}


### PR DESCRIPTION
Add swapper contracts for buying, selling, and redeeming Pendle Principal Tokens (PT):

- PendleSwapper: Base implementation with multi-market support
  - Buy PT via Pendle AMM
  - Sell PT pre-expiry via AMM
  - Auto-redeem PT post-expiry
  - Default ApproxParams for simplicity

- PendleSwapperWithAggregator: Extended version supporting arbitrary input tokens via DEX aggregators (1inch, Kyberswap, etc.)

- Includes Pendle protocol interfaces (IPendleRouter, IPMarket, etc.)
- Unit tests and mock contracts for testing