### PR TITLE
fix: allow settle to clear empty inactive lots

### DIFF
--- a/src/Auctions/Auction.sol
+++ b/src/Auctions/Auction.sol
@@ -766,7 +766,7 @@ contract Auction is Governance2Step, ReentrancyGuard {
      * @param _from The address of the token to be auctioned.
      */
     function settle(address _from) external virtual {
-        require(isActive(_from), "!active");
+        require(auctions[_from].kicked != 0, "!kicked");
         require(ERC20(_from).balanceOf(address(this)) == 0, "!empty");
 
         auctions[_from].kicked = uint64(0);


### PR DESCRIPTION
## Problem
An empty lot can remain in a kicked state after it has been fully sold.

If that lot later falls below the minimum price, isActive(_from) becomes false and settle(_from) can no longer clear it, because settle() currently requires the lot to be active.

This becomes a problem because auction pricing is global. A later increase to startingPrice for a different token can make the old empty lot active again, allowing that stale state to block future parameter updates or kicks.

#### Example

  1. Token A is kicked.
  2. Its balance is fully sold to 0, but kicked remains set.
  3. Under the current params, price(A) == 0, so isActive(A) == false.
  4. Governance later raises the global startingPrice for token B.
  5. That change makes price(A) > 0 again, even though balance(A) == 0.
  6. The empty stale lot is now active again and can block subsequent updates.

## Solution

Allow settle() to clear any kicked lot with zero balance, regardless of whether it is currently active.