### PR TITLE
fix: clamp max uint deposit hook assets

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,12 +13,12 @@ jobs:
 
       steps:
       - name: Check out github repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 1
 
       - name: Setup node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
 
@@ -27,7 +27,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Restore yarn cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: yarn-cache
         with:
           path: |
@@ -50,9 +50,9 @@ jobs:
 
       steps:
       - name: Check out github repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 0
 
       - name: Run commitlint
-        uses: wagoid/commitlint-github-action@v2
+        uses: wagoid/commitlint-github-action@4b1bcb1c72f99fbd6aa6b34cc3fb59200f01f993 # v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.10'
 
@@ -28,7 +28,7 @@ jobs:
         run: pip install vyper==0.3.7
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
 
       - name: Run Forge build
         run: |

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,3 @@
+npmMinimalAgeGate: 10080
+enableScripts: false
+defaultSemverRangePrefix: ""

--- a/package.json
+++ b/package.json
@@ -1,17 +1,18 @@
 {
     "name": "yearn_base_strategy",
     "devDependencies": {
-        "prettier": "^2.5.1",
-        "prettier-plugin-solidity": "^1.0.0-beta.19",
-        "pretty-quick": "^3.1.3",
+        "prettier": "2.8.8",
+        "prettier-plugin-solidity": "1.1.3",
+        "pretty-quick": "3.1.3",
         "solc": "0.8.18",
-        "solhint": "^3.3.7",
-        "solhint-plugin-prettier": "^0.0.5"
+        "solhint": "3.4.1",
+        "solhint-plugin-prettier": "0.0.5"
     },
     "scripts": {
         "format": "prettier --write 'src/**/*.(sol|json)'",
         "format:check": "prettier --check 'src/**/*.*(sol|json)'",
         "lint": "solhint 'src/**/*.sol'",
         "lint:fix": "solhint --fix 'src/**/*.sol'"
-    }
-  }
+    },
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+}

--- a/src/Bases/Hooks/BaseHooks.sol
+++ b/src/Bases/Hooks/BaseHooks.sol
@@ -17,6 +17,10 @@ abstract contract BaseHooks is BaseHealthCheck, Hooks {
         uint256 assets,
         address receiver
     ) external virtual returns (uint256 shares) {
+        if (assets == type(uint256).max) {
+            assets = asset.balanceOf(msg.sender);
+        }
+
         _preDepositHook(assets, shares, receiver);
         shares = abi.decode(
             _delegateCall(

--- a/src/Bases/Upgradeable/BaseHooksUpgradeable.sol
+++ b/src/Bases/Upgradeable/BaseHooksUpgradeable.sol
@@ -77,6 +77,10 @@ abstract contract BaseHooksUpgradeable is BaseHealthCheckUpgradeable, Hooks {
         uint256 assets,
         address receiver
     ) external virtual returns (uint256 shares) {
+        if (assets == type(uint256).max) {
+            assets = asset.balanceOf(msg.sender);
+        }
+
         _preDepositHook(assets, shares, receiver);
         shares = abi.decode(
             _delegateCall(

--- a/src/test/BaseHook.t.sol
+++ b/src/test/BaseHook.t.sol
@@ -47,6 +47,28 @@ contract BaseHookTest is Setup, HookEvents {
         assertEq(mockStrategy.balanceOf(user), _amount);
     }
 
+    function test_depositHooksClampMaxUint(uint256 _amount) public {
+        vm.assume(_amount >= minFuzzAmount && _amount <= maxFuzzAmount);
+
+        airdrop(asset, user, _amount);
+        uint256 assets = asset.balanceOf(user);
+
+        vm.startPrank(user);
+        asset.forceApprove(address(mockStrategy), type(uint256).max);
+        vm.stopPrank();
+
+        vm.expectEmit(true, true, true, true, address(mockStrategy));
+        emit PreDepositHook(assets, 0, user);
+
+        vm.expectEmit(true, true, true, true, address(mockStrategy));
+        emit PostDepositHook(assets, assets, user);
+
+        vm.prank(user);
+        mockStrategy.deposit(type(uint256).max, user);
+
+        assertEq(mockStrategy.balanceOf(user), assets);
+    }
+
     function test_mintHooks(uint256 _amount) public {
         vm.assume(_amount >= minFuzzAmount && _amount <= maxFuzzAmount);
 

--- a/src/test/upgradeable/BaseHooksUpgradeable.t.sol
+++ b/src/test/upgradeable/BaseHooksUpgradeable.t.sol
@@ -51,6 +51,28 @@ contract BaseHooksUpgradeableTest is UpgradeableSetup, HookEvents {
         assertEq(mockStrategy.balanceOf(user), _amount);
     }
 
+    function test_depositHooksUpgradeableClampMaxUint(uint256 _amount) public {
+        vm.assume(_amount >= minFuzzAmount && _amount <= maxFuzzAmount);
+
+        airdrop(asset, user, _amount);
+        uint256 assets = asset.balanceOf(user);
+
+        vm.startPrank(user);
+        asset.forceApprove(address(mockStrategy), type(uint256).max);
+        vm.stopPrank();
+
+        vm.expectEmit(true, true, true, true, address(mockStrategy));
+        emit PreDepositHook(assets, 0, user);
+
+        vm.expectEmit(true, true, true, true, address(mockStrategy));
+        emit PostDepositHook(assets, assets, user);
+
+        vm.prank(user);
+        mockStrategy.deposit(type(uint256).max, user);
+
+        assertEq(mockStrategy.balanceOf(user), assets);
+    }
+
     function test_mintHooksUpgradeable(uint256 _amount) public {
         vm.assume(_amount >= minFuzzAmount && _amount <= maxFuzzAmount);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -573,23 +573,23 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier-plugin-solidity@^1.0.0-beta.19:
+prettier-plugin-solidity@1.1.3:
   version "1.1.3"
-  resolved "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.1.3.tgz"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.1.3.tgz#9a35124f578404caf617634a8cab80862d726cba"
   integrity sha512-fQ9yucPi2sBbA2U2Xjh6m4isUTJ7S7QLc/XDDsktqqxYfTwdYKJ0EnnywXHwCGAaYbQNK+HIYPL1OemxuMsgeg==
   dependencies:
     "@solidity-parser/parser" "^0.16.0"
     semver "^7.3.8"
     solidity-comments-extractor "^0.0.7"
 
-prettier@^2.5.1, prettier@^2.8.3:
+prettier@2.8.8, prettier@^2.8.3:
   version "2.8.8"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
-pretty-quick@^3.1.3:
+pretty-quick@3.1.3:
   version "3.1.3"
-  resolved "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.1.3.tgz"
+  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-3.1.3.tgz#15281108c0ddf446675157ca40240099157b638e"
   integrity sha512-kOCi2FJabvuh1as9enxYmrnBC6tVMoVOenMaBqRfsvBHB0cbpYHjdQEpSglpASDFEXVwplpcGR4CLEaisYAFcA==
   dependencies:
     chalk "^3.0.0"
@@ -678,16 +678,16 @@ solc@0.8.18:
     semver "^5.5.0"
     tmp "0.0.33"
 
-solhint-plugin-prettier@^0.0.5:
+solhint-plugin-prettier@0.0.5:
   version "0.0.5"
-  resolved "https://registry.npmjs.org/solhint-plugin-prettier/-/solhint-plugin-prettier-0.0.5.tgz"
+  resolved "https://registry.yarnpkg.com/solhint-plugin-prettier/-/solhint-plugin-prettier-0.0.5.tgz#e3b22800ba435cd640a9eca805a7f8bc3e3e6a6b"
   integrity sha512-7jmWcnVshIrO2FFinIvDQmhQpfpS2rRRn3RejiYgnjIE68xO2bvrYvjqVNfrio4xH9ghOqn83tKuTzLjEbmGIA==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-solhint@^3.3.7:
+solhint@3.4.1:
   version "3.4.1"
-  resolved "https://registry.npmjs.org/solhint/-/solhint-3.4.1.tgz"
+  resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.4.1.tgz#8ea15b21c13d1be0b53fd46d605a24d0b36a0c46"
   integrity sha512-pzZn2RlZhws1XwvLPVSsxfHrwsteFf5eySOhpAytzXwKQYbTCJV6z8EevYDiSVKMpWrvbKpEtJ055CuEmzp4Xg==
   dependencies:
     "@solidity-parser/parser" "^0.16.0"


### PR DESCRIPTION
## Summary
- Clamp max-uint deposit inputs before pre/post deposit hooks so hooks receive the actual sender balance deposited.
- Add regression coverage for standard and upgradeable hook bases.
