### PR TITLE
feat: protect auction tokens

### DIFF
--- a/src/Bases/convertors/BaseConvertor.sol
+++ b/src/Bases/convertors/BaseConvertor.sol
@@ -147,7 +147,10 @@ contract BaseConvertor is BaseHealthCheck {
     }
 
     /// @notice Management passthrough to enable an auction token.
+    /// @dev Reverts if `_from` is in `protectedTokens()` so a protected token
+    ///      can never be added to the auction's enabled set.
     function enableAuctionToken(address _from) external onlyManagement {
+        require(!_isProtectedToken(_from), "protected token");
         _auctionForToken(_from).enable(_from);
     }
 
@@ -201,7 +204,6 @@ contract BaseConvertor is BaseHealthCheck {
     }
 
     /// @notice Tokens that should never be kicked into auction.
-    /// @dev Override in subclasses to add protected tokens (e.g. vault shares).
     function protectedTokens() public view virtual returns (address[] memory) {
         return new address[](0);
     }

--- a/src/Bases/convertors/BaseConvertor.sol
+++ b/src/Bases/convertors/BaseConvertor.sol
@@ -23,6 +23,11 @@ interface IMorphoOracle {
 contract BaseConvertor is BaseHealthCheck {
     using SafeERC20 for ERC20;
 
+    modifier onlyGov() {
+        require(msg.sender == GOV, "!gov");
+        _;
+    }
+
     event OracleSet(address indexed oracle);
     event MaxSlippageBpsSet(uint16 indexed maxSlippageBps);
     event StartingPriceBpsSet(uint16 indexed startingPriceBps);
@@ -116,11 +121,6 @@ contract BaseConvertor is BaseHealthCheck {
 
     function setMinAmountToSell(address _from, uint256 _minAmountToSell) external onlyManagement {
         _setMinAmountToSell(_from, _minAmountToSell);
-    }
-
-    modifier onlyGov() {
-        require(msg.sender == GOV, "!gov");
-        _;
     }
 
     function setOracle(address _oracle) external onlyGov {

--- a/src/Bases/convertors/BaseConvertor.sol
+++ b/src/Bases/convertors/BaseConvertor.sol
@@ -97,6 +97,10 @@ contract BaseConvertor is BaseHealthCheck {
         _setStartingPriceBps(uint16(MAX_BPS + 5));
         _setMaxSlippageBps(5);
         _setOracle(_oracle);
+
+        // Default to no triggers until minAmountToSell is set per-token.
+        _setMinAmountToSell(_asset, type(uint256).max);
+        _setMinAmountToSell(_want, type(uint256).max);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -165,6 +169,7 @@ contract BaseConvertor is BaseHealthCheck {
     }
 
     function _kickAuction(address _from) internal virtual returns (uint256) {
+        require(!_isProtectedToken(_from), "protected token");
         if (_from == address(WANT)) {
             return _kickConfiguredAuction(BUY_ASSET_AUCTION, _from, type(uint256).max);
         }
@@ -172,6 +177,7 @@ contract BaseConvertor is BaseHealthCheck {
     }
 
     function kickable(address _from) public view virtual returns (uint256) {
+        if (_isProtectedToken(_from)) return 0;
         if (_from == address(WANT)) {
             return _kickableFromAuction(BUY_ASSET_AUCTION, _from);
         }
@@ -181,6 +187,7 @@ contract BaseConvertor is BaseHealthCheck {
     /// @notice We use trigger to go from asset -> want.
     /// We cannot assume loose want should be converted, so it does not go back.
     function auctionTrigger(address _from) external view returns (bool shouldKick, bytes memory data) {
+        if (_isProtectedToken(_from)) return (false, bytes("protected token"));
         if (_from == address(WANT)) return (false, bytes("want"));
 
         if (!(_isBaseFeeAcceptable())) return (false, bytes("base fee"));
@@ -191,6 +198,21 @@ contract BaseConvertor is BaseHealthCheck {
         }
 
         return (false, bytes("not enough kickable"));
+    }
+
+    /// @notice Tokens that should never be kicked into auction.
+    /// @dev Override in subclasses to add protected tokens (e.g. vault shares).
+    function protectedTokens() public view virtual returns (address[] memory) {
+        return new address[](0);
+    }
+
+    function _isProtectedToken(address _token) internal view virtual returns (bool) {
+        address[] memory _protectedTokens = protectedTokens();
+        uint256 length = _protectedTokens.length;
+        for (uint256 i; i < length; ++i) {
+            if (_protectedTokens[i] == _token) return true;
+        }
+        return false;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/Bases/convertors/BaseConvertor.sol
+++ b/src/Bases/convertors/BaseConvertor.sol
@@ -42,6 +42,9 @@ contract BaseConvertor is BaseHealthCheck {
     /// @notice Token converted to/from strategy `asset`.
     ERC20 public immutable WANT;
 
+    /// @notice Address allowed to update the oracle.
+    address public immutable GOV;
+
     /// @notice Auction selling `asset` into `want`.
     Auction public immutable SELL_ASSET_AUCTION;
 
@@ -73,8 +76,12 @@ contract BaseConvertor is BaseHealthCheck {
     /// @dev Zero means unlimited.
     mapping(address => uint256) public maxAmountToSwap;
 
-    constructor(address _asset, string memory _name, address _want, address _oracle) BaseHealthCheck(_asset, _name) {
+    constructor(address _asset, string memory _name, address _want, address _oracle, address _gov)
+        BaseHealthCheck(_asset, _name)
+    {
+        require(_gov != address(0), "ZERO ADDRESS");
         WANT = ERC20(_want);
+        GOV = _gov;
 
         AuctionFactory factory = AuctionFactory(0xbA7FCb508c7195eE5AE823F37eE2c11D7ED52F8e);
 
@@ -111,7 +118,12 @@ contract BaseConvertor is BaseHealthCheck {
         _setMinAmountToSell(_from, _minAmountToSell);
     }
 
-    function setOracle(address _oracle) external onlyManagement {
+    modifier onlyGov() {
+        require(msg.sender == GOV, "!gov");
+        _;
+    }
+
+    function setOracle(address _oracle) external onlyGov {
         _setOracle(_oracle);
     }
 

--- a/src/Bases/convertors/BaseConvertor.sol
+++ b/src/Bases/convertors/BaseConvertor.sol
@@ -28,7 +28,7 @@ contract BaseConvertor is BaseHealthCheck {
     event StartingPriceBpsSet(uint16 indexed startingPriceBps);
     event DecayRateSet(uint256 indexed decayRate);
     event ReportBufferSet(uint16 indexed reportBuffer);
-    event MinAmountToSellSet(uint256 indexed minAmountToSell);
+    event MinAmountToSellSet(address indexed from, uint256 indexed minAmountToSell);
     event MaxAmountToSwapSet(address indexed from, uint256 indexed maxAmountToSwap);
     event MaxGasPriceToTendSet(uint256 indexed maxGasPriceToTend);
 
@@ -61,7 +61,7 @@ contract BaseConvertor is BaseHealthCheck {
     uint16 public startingPriceBps;
 
     /// @notice Minimum amount required before an auction kick is allowed.
-    uint256 public minAmountToSell;
+    mapping(address => uint256) public minAmountToSell;
 
     /// @notice Management configured step decay rate applied to asset/want auctions.
     uint256 public decayRate;
@@ -97,16 +97,14 @@ contract BaseConvertor is BaseHealthCheck {
         _setStartingPriceBps(uint16(MAX_BPS + 5));
         _setMaxSlippageBps(5);
         _setOracle(_oracle);
-        // Default to no triggers until minAmountToSell is set.
-        _setMinAmountToSell(type(uint256).max);
     }
 
     /*//////////////////////////////////////////////////////////////
                         MANAGEMENT CONFIG
     //////////////////////////////////////////////////////////////*/
 
-    function setMinAmountToSell(uint256 _minAmountToSell) external onlyManagement {
-        _setMinAmountToSell(_minAmountToSell);
+    function setMinAmountToSell(address _from, uint256 _minAmountToSell) external onlyManagement {
+        _setMinAmountToSell(_from, _minAmountToSell);
     }
 
     function setOracle(address _oracle) external onlyManagement {
@@ -188,7 +186,7 @@ contract BaseConvertor is BaseHealthCheck {
         if (!(_isBaseFeeAcceptable())) return (false, bytes("base fee"));
 
         uint256 kickableAmount = kickable(_from);
-        if (kickableAmount >= minAmountToSell) {
+        if (kickableAmount != 0 && kickableAmount >= minAmountToSell[_from]) {
             return (true, abi.encodeCall(this.kickAuction, (_from)));
         }
 
@@ -260,9 +258,12 @@ contract BaseConvertor is BaseHealthCheck {
         emit OracleSet(_oracle);
     }
 
-    function _setMinAmountToSell(uint256 _minAmountToSell) internal virtual {
-        minAmountToSell = _minAmountToSell;
-        emit MinAmountToSellSet(_minAmountToSell);
+    function _setMinAmountToSell(
+        address _from,
+        uint256 _minAmountToSell
+    ) internal virtual {
+        minAmountToSell[_from] = _minAmountToSell;
+        emit MinAmountToSellSet(_from, _minAmountToSell);
     }
 
     function _setMaxAmountToSwap(address _from, uint256 _maxAmountToSwap) internal virtual {

--- a/src/Bases/convertors/BaseConvertor4626.sol
+++ b/src/Bases/convertors/BaseConvertor4626.sol
@@ -58,11 +58,9 @@ contract BaseConvertor4626 is BaseConvertor {
         return _quoteAssetFromWant(vault.convertToAssets(vault.maxRedeem(address(this))));
     }
 
-    function kickable(
-        address _from
-    ) public view virtual override returns (uint256) {
-        if (_from == address(vault)) return 0;
-        return super.kickable(_from);
+    function protectedTokens() public view virtual override returns (address[] memory _protected) {
+        _protected = new address[](1);
+        _protected[0] = address(vault);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -117,13 +115,6 @@ contract BaseConvertor4626 is BaseConvertor {
     /*//////////////////////////////////////////////////////////////
                           INTERNAL ACTIONS
     //////////////////////////////////////////////////////////////*/
-
-    function _kickAuction(
-        address _from
-    ) internal virtual override returns (uint256) {
-        require(_from != address(vault), "protected token");
-        return super._kickAuction(_from);
-    }
 
     function _deployLooseWant() internal virtual returns (uint256 _deployed) {
         _deployed = _deployableWant();

--- a/src/Bases/convertors/BaseConvertor4626.sol
+++ b/src/Bases/convertors/BaseConvertor4626.sol
@@ -58,6 +58,13 @@ contract BaseConvertor4626 is BaseConvertor {
         return _quoteAssetFromWant(vault.convertToAssets(vault.maxRedeem(address(this))));
     }
 
+    function kickable(
+        address _from
+    ) public view virtual override returns (uint256) {
+        if (_from == address(vault)) return 0;
+        return super.kickable(_from);
+    }
+
     /*//////////////////////////////////////////////////////////////
                            INTERNAL VIEWS
     //////////////////////////////////////////////////////////////*/
@@ -96,7 +103,7 @@ contract BaseConvertor4626 is BaseConvertor {
 
     function _tendTrigger() internal view virtual override returns (bool) {
         if (!(_isBaseFeeAcceptable())) return false;
-        return _deployableWant() > minAmountToSell;
+        return _deployableWant() > minAmountToSell[address(WANT)];
     }
 
     function totalWant() public view virtual override returns (uint256) {
@@ -110,6 +117,13 @@ contract BaseConvertor4626 is BaseConvertor {
     /*//////////////////////////////////////////////////////////////
                           INTERNAL ACTIONS
     //////////////////////////////////////////////////////////////*/
+
+    function _kickAuction(
+        address _from
+    ) internal virtual override returns (uint256) {
+        require(_from != address(vault), "protected token");
+        return super._kickAuction(_from);
+    }
 
     function _deployLooseWant() internal virtual returns (uint256 _deployed) {
         _deployed = _deployableWant();

--- a/src/Bases/convertors/BaseConvertor4626.sol
+++ b/src/Bases/convertors/BaseConvertor4626.sol
@@ -18,8 +18,8 @@ contract BaseConvertor4626 is BaseConvertor {
 
     IERC4626 public immutable vault;
 
-    constructor(address _asset, string memory _name, address _want, address _oracle, address _vault)
-        BaseConvertor(_asset, _name, _want, _oracle)
+    constructor(address _asset, string memory _name, address _want, address _oracle, address _vault, address _gov)
+        BaseConvertor(_asset, _name, _want, _oracle, _gov)
     {
         vault = IERC4626(_vault);
         require(vault.asset() == _want, "wrong vault");

--- a/src/Bases/convertors/Convertor4626Factory.sol
+++ b/src/Bases/convertors/Convertor4626Factory.sol
@@ -25,15 +25,19 @@ contract Convertor4626Factory {
         emergencyAdmin = _emergencyAdmin;
     }
 
-    function newConvertor4626(address _asset, string calldata _name, address _want, address _oracle, address _vault)
-        external
-        returns (address)
-    {
+    function newConvertor4626(
+        address _asset,
+        string calldata _name,
+        address _want,
+        address _oracle,
+        address _vault,
+        address _gov
+    ) external returns (address) {
         address deployed = deployments4626[_asset][_want][_vault];
         if (deployed != address(0)) revert AlreadyDeployed(deployed);
 
         IBaseConvertor4626 _newConvertor =
-            IBaseConvertor4626(address(new BaseConvertor4626(_asset, _name, _want, _oracle, _vault)));
+            IBaseConvertor4626(address(new BaseConvertor4626(_asset, _name, _want, _oracle, _vault, _gov)));
 
         _configureStrategy(_newConvertor);
 

--- a/src/Bases/convertors/ConvertorFactory.sol
+++ b/src/Bases/convertors/ConvertorFactory.sol
@@ -24,14 +24,14 @@ contract ConvertorFactory {
         emergencyAdmin = _emergencyAdmin;
     }
 
-    function newConvertor(address _asset, string calldata _name, address _want, address _oracle)
+    function newConvertor(address _asset, string calldata _name, address _want, address _oracle, address _gov)
         external
         returns (address)
     {
         address deployed = deployments[_asset][_want];
         if (deployed != address(0)) revert AlreadyDeployed(deployed);
 
-        IBaseConvertor _newConvertor = IBaseConvertor(address(new BaseConvertor(_asset, _name, _want, _oracle)));
+        IBaseConvertor _newConvertor = IBaseConvertor(address(new BaseConvertor(_asset, _name, _want, _oracle, _gov)));
 
         _configureStrategy(_newConvertor);
 

--- a/src/Bases/convertors/IBaseConvertor.sol
+++ b/src/Bases/convertors/IBaseConvertor.sol
@@ -59,6 +59,8 @@ interface IBaseConvertor is IBaseHealthCheck {
 
     function auctionTrigger(address _from) external view returns (bool shouldKick, bytes memory data);
 
+    function protectedTokens() external view returns (address[] memory);
+
     function balanceOfAsset() external view returns (uint256);
 
     function balanceOfWant() external view returns (uint256);

--- a/src/Bases/convertors/IBaseConvertor.sol
+++ b/src/Bases/convertors/IBaseConvertor.sol
@@ -20,7 +20,7 @@ interface IBaseConvertor is IBaseHealthCheck {
 
     function reportBuffer() external view returns (uint16);
 
-    function minAmountToSell() external view returns (uint256);
+    function minAmountToSell(address _from) external view returns (uint256);
 
     function maxAmountToSwap(address _from) external view returns (uint256);
 
@@ -28,7 +28,10 @@ interface IBaseConvertor is IBaseHealthCheck {
 
     function setOracle(address _oracle) external;
 
-    function setMinAmountToSell(uint256 _minAmountToSell) external;
+    function setMinAmountToSell(
+        address _from,
+        uint256 _minAmountToSell
+    ) external;
 
     function setMaxAmountToSwap(address _from, uint256 _maxAmountToSwap) external;
 

--- a/src/Bases/convertors/IBaseConvertor.sol
+++ b/src/Bases/convertors/IBaseConvertor.sol
@@ -6,6 +6,8 @@ import {IBaseHealthCheck} from "../HealthCheck/IBaseHealthCheck.sol";
 interface IBaseConvertor is IBaseHealthCheck {
     function WANT() external view returns (address);
 
+    function GOV() external view returns (address);
+
     function SELL_ASSET_AUCTION() external view returns (address);
 
     function BUY_ASSET_AUCTION() external view returns (address);

--- a/src/swappers/AuctionSwapper.sol
+++ b/src/swappers/AuctionSwapper.sol
@@ -168,7 +168,9 @@ abstract contract AuctionSwapper is BaseSwapper {
 
         uint256 kickableAmount = kickable(_from);
 
-        if (kickableAmount != 0 && kickableAmount >= minAmountToSell) {
+        if (
+            kickableAmount != 0 && kickableAmount >= minAmountToSell[_from]
+        ) {
             return (true, abi.encodeCall(this.kickAuction, (_from)));
         }
 

--- a/src/swappers/AuctionSwapper.sol
+++ b/src/swappers/AuctionSwapper.sol
@@ -38,7 +38,7 @@ import {BaseSwapper} from "./BaseSwapper.sol";
  *   - If hooks are not desired, call `setHookFlags()` on the auction contract
  *     to avoid unnecessary gas for unused functions
  */
-contract AuctionSwapper is BaseSwapper {
+abstract contract AuctionSwapper is BaseSwapper {
     using SafeERC20 for ERC20;
 
     event AuctionSet(address indexed auction);
@@ -51,6 +51,9 @@ contract AuctionSwapper is BaseSwapper {
     /// @dev Defaults to false but automatically set to true when setting a non-zero auction address.
     ///      Can be manually controlled via _setUseAuction() for fine-grained control.
     bool public useAuction;
+
+    /// @notice Tokens that should never be kicked into auction.
+    function protectedTokens() public view virtual returns (address[] memory);
 
     /*//////////////////////////////////////////////////////////////
                     AUCTION STARTING AND STOPPING
@@ -87,6 +90,7 @@ contract AuctionSwapper is BaseSwapper {
      * @return The total amount of `_token` available for auction (0 if auctions disabled).
      */
     function kickable(address _token) public view virtual returns (uint256) {
+        if (_isProtectedToken(_token)) return 0;
         if (!useAuction) return 0;
 
         address _auction = auction;
@@ -115,6 +119,7 @@ contract AuctionSwapper is BaseSwapper {
      * @param _from The token that was being sold.
      */
     function _kickAuction(address _from) internal virtual returns (uint256) {
+        require(!_isProtectedToken(_from), "protected token");
         require(useAuction, "useAuction is false");
         address _auction = auction;
 
@@ -148,6 +153,10 @@ contract AuctionSwapper is BaseSwapper {
      *              otherwise a descriptive error message explaining why not.
      */
     function auctionTrigger(address _from) external view virtual returns (bool shouldKick, bytes memory data) {
+        if (_isProtectedToken(_from)) {
+            return (false, bytes("protected token"));
+        }
+
         address _auction = auction;
         if (_auction == address(0)) {
             return (false, bytes("No auction set"));
@@ -164,5 +173,18 @@ contract AuctionSwapper is BaseSwapper {
         }
 
         return (false, bytes("not enough kickable"));
+    }
+
+    function _isProtectedToken(
+        address _token
+    ) internal view virtual returns (bool) {
+        address[] memory _protectedTokens = protectedTokens();
+        uint256 length = _protectedTokens.length;
+
+        for (uint256 i; i < length; ++i) {
+            if (_protectedTokens[i] == _token) return true;
+        }
+
+        return false;
     }
 }

--- a/src/swappers/BaseSwapper.sol
+++ b/src/swappers/BaseSwapper.sol
@@ -5,17 +5,21 @@ pragma solidity >=0.8.18;
  * @title BaseSwapper
  * @author yearn.fi
  * @dev Base contract for all swapper contracts except TradeFactorySwapper.
- *      Contains the common minAmountToSell variable that most swappers need.
+ *      Contains the common minAmountToSell mapping that most swappers need.
  */
 contract BaseSwapper {
     /// @notice Minimum amount of tokens to sell in a swap.
-    uint256 public minAmountToSell;
+    mapping(address => uint256) public minAmountToSell;
 
     /**
      * @dev Set the minimum amount to sell in a swap.
+     * @param _token Token to set the minimum for.
      * @param _minAmountToSell Minimum amount of tokens needed to execute a swap.
      */
-    function _setMinAmountToSell(uint256 _minAmountToSell) internal virtual {
-        minAmountToSell = _minAmountToSell;
+    function _setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) internal virtual {
+        minAmountToSell[_token] = _minAmountToSell;
     }
 }

--- a/src/swappers/CurveSwapper.sol
+++ b/src/swappers/CurveSwapper.sol
@@ -73,7 +73,7 @@ contract CurveSwapper is BaseSwapper {
         virtual
         returns (uint256 _amountOut)
     {
-        if (_amountIn != 0 && _amountIn >= minAmountToSell) {
+        if (_amountIn != 0 && _amountIn >= minAmountToSell[_from]) {
             _checkAllowance(curveRouter, _from, _amountIn);
 
             CurveRouteParams storage params = _curveRoutes[_from][_to];

--- a/src/swappers/FluidSwapper.sol
+++ b/src/swappers/FluidSwapper.sol
@@ -99,7 +99,7 @@ contract FluidSwapper is BaseSwapper {
         virtual
         returns (uint256 _amountOut)
     {
-        if (_amountIn != 0 && _amountIn >= minAmountToSell) {
+        if (_amountIn != 0 && _amountIn >= minAmountToSell[_from]) {
             if (_from == WETH) {
                 IWETH(WETH).withdraw(_amountIn);
             }

--- a/src/swappers/PendleSwapper.sol
+++ b/src/swappers/PendleSwapper.sol
@@ -84,7 +84,7 @@ contract PendleSwapper is BaseSwapper {
         virtual
         returns (uint256 _amountOut)
     {
-        if (_amountIn == 0 || _amountIn < minAmountToSell) {
+        if (_amountIn == 0 || _amountIn < minAmountToSell[_from]) {
             return 0;
         }
 

--- a/src/swappers/PendleSwapperWithAggregator.sol
+++ b/src/swappers/PendleSwapperWithAggregator.sol
@@ -50,7 +50,7 @@ contract PendleSwapperWithAggregator is PendleSwapper {
         address _tokenMintSy,
         SwapData calldata _swapData
     ) internal virtual returns (uint256 _amountOut) {
-        if (_amountIn == 0 || _amountIn < minAmountToSell) {
+        if (_amountIn == 0 || _amountIn < minAmountToSell[_tokenIn]) {
             return 0;
         }
 
@@ -94,7 +94,7 @@ contract PendleSwapperWithAggregator is PendleSwapper {
         address _tokenRedeemSy,
         SwapData calldata _swapData
     ) internal virtual returns (uint256 _amountOut) {
-        if (_amountIn == 0 || _amountIn < minAmountToSell) {
+        if (_amountIn == 0 || _amountIn < minAmountToSell[_pt]) {
             return 0;
         }
 

--- a/src/swappers/SolidlySwapper.sol
+++ b/src/swappers/SolidlySwapper.sol
@@ -60,7 +60,7 @@ contract SolidlySwapper is BaseSwapper {
      * @param _minAmountOut The min of `_to` to get out.
      */
     function _swapFrom(address _from, address _to, uint256 _amountIn, uint256 _minAmountOut) internal virtual {
-        if (_amountIn > minAmountToSell) {
+        if (_amountIn != 0 && _amountIn >= minAmountToSell[_from]) {
             _checkAllowance(router, _from, _amountIn);
 
             ISolidly(router)

--- a/src/swappers/UniswapUniversalSwapper.sol
+++ b/src/swappers/UniswapUniversalSwapper.sol
@@ -137,7 +137,7 @@ contract UniswapUniversalSwapper is BaseSwapper {
         virtual
         returns (uint256 _amountOut)
     {
-        if (_amountIn == 0 || _amountIn < minAmountToSell) return 0;
+        if (_amountIn == 0 || _amountIn < minAmountToSell[_from]) return 0;
 
         bytes memory commands;
         bytes[] memory inputs;

--- a/src/swappers/UniswapV2Swapper.sol
+++ b/src/swappers/UniswapV2Swapper.sol
@@ -41,7 +41,7 @@ contract UniswapV2Swapper is BaseSwapper {
      * @param _minAmountOut The min of `_to` to get out.
      */
     function _swapFrom(address _from, address _to, uint256 _amountIn, uint256 _minAmountOut) internal virtual {
-        if (_amountIn > minAmountToSell) {
+        if (_amountIn != 0 && _amountIn >= minAmountToSell[_from]) {
             _checkAllowance(router, _from, _amountIn);
 
             IUniswapV2Router02(router)

--- a/src/swappers/UniswapV3Swapper.sol
+++ b/src/swappers/UniswapV3Swapper.sol
@@ -69,7 +69,7 @@ contract UniswapV3Swapper is BaseSwapper {
         virtual
         returns (uint256 _amountOut)
     {
-        if (_amountIn != 0 && _amountIn >= minAmountToSell) {
+        if (_amountIn != 0 && _amountIn >= minAmountToSell[_from]) {
             _checkAllowance(router, _from, _amountIn);
             if (_from == base || _to == base) {
                 ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams(
@@ -125,7 +125,7 @@ contract UniswapV3Swapper is BaseSwapper {
         virtual
         returns (uint256 _amountIn)
     {
-        if (_maxAmountFrom != 0 && _maxAmountFrom >= minAmountToSell) {
+        if (_maxAmountFrom != 0 && _maxAmountFrom >= minAmountToSell[_from]) {
             _checkAllowance(router, _from, _maxAmountFrom);
             if (_from == base || _to == base) {
                 ISwapRouter.ExactOutputSingleParams memory params = ISwapRouter.ExactOutputSingleParams(

--- a/src/swappers/interfaces/IAuctionSwapper.sol
+++ b/src/swappers/interfaces/IAuctionSwapper.sol
@@ -11,6 +11,8 @@ interface IAuctionSwapper is IBaseSwapper {
 
     function useAuction() external view returns (bool);
 
+    function protectedTokens() external view returns (address[] memory);
+
     function kickable(address _fromToken) external view returns (uint256);
 
     function kickAuction(address _from) external returns (uint256);

--- a/src/swappers/interfaces/IBaseSwapper.sol
+++ b/src/swappers/interfaces/IBaseSwapper.sol
@@ -2,5 +2,5 @@
 pragma solidity >=0.8.18;
 
 interface IBaseSwapper {
-    function minAmountToSell() external view returns (uint256);
+    function minAmountToSell(address _token) external view returns (uint256);
 }

--- a/src/test/AuctionSwapper.t.sol
+++ b/src/test/AuctionSwapper.t.sol
@@ -185,6 +185,42 @@ contract AuctionSwapperTest is Setup {
         swapper.kickAuction(from);
     }
 
+    function test_protectedToken_blocksKickViewsAndTrigger() public {
+        address from = tokenAddrs["WBTC"];
+        uint256 amount = 1e8;
+
+        address newAuction = auctionFactory.createNewAuction(
+            address(asset),
+            address(swapper),
+            address(this),
+            1e6
+        );
+        swapper.setAuction(newAuction);
+        auction = Auction(newAuction);
+        auction.enable(from);
+
+        address[] memory protectedTokens = new address[](1);
+        protectedTokens[0] = from;
+        swapper.setProtectedTokens(protectedTokens);
+
+        airdrop(ERC20(from), address(swapper), amount);
+
+        address[] memory configuredTokens = swapper.protectedTokens();
+        assertEq(configuredTokens.length, 1);
+        assertEq(configuredTokens[0], from);
+        assertEq(swapper.kickable(from), 0);
+
+        (bool shouldKick, bytes memory data) = swapper.auctionTrigger(from);
+        assertFalse(shouldKick);
+        assertEq(data, bytes("protected token"));
+
+        vm.expectRevert("protected token");
+        swapper.kickAuction(from);
+
+        assertEq(ERC20(from).balanceOf(address(swapper)), amount);
+        assertEq(ERC20(from).balanceOf(address(auction)), 0);
+    }
+
     function test_kickAuction_default(uint256 _amount) public {
         vm.assume(_amount >= minFuzzAmount && _amount <= maxFuzzAmount);
 

--- a/src/test/AuctionSwapper.t.sol
+++ b/src/test/AuctionSwapper.t.sol
@@ -589,7 +589,7 @@ contract AuctionSwapperTest is Setup {
         assertEq(data, expectedData);
 
         // Set minAmountToSell to test the threshold
-        swapper.setMinAmountToSell(2e8); // Set higher than our balance
+        swapper.setMinAmountToSell(from, 2e8); // Set higher than our balance
 
         // Should not kick due to insufficient amount
         (shouldKick, data) = swapper.auctionTrigger(from);
@@ -597,7 +597,7 @@ contract AuctionSwapperTest is Setup {
         assertEq(data, bytes("not enough kickable"));
 
         // Reset minAmountToSell to 0 and kick the auction
-        swapper.setMinAmountToSell(0);
+        swapper.setMinAmountToSell(from, 0);
         swapper.kickAuction(from);
 
         // Should not kick again while active with available tokens (kickable returns 0)
@@ -639,7 +639,7 @@ contract AuctionSwapperTest is Setup {
         assertEq(data, expectedData);
 
         // Set minAmountToSell higher than our balance
-        swapper.setMinAmountToSell(2e8);
+        swapper.setMinAmountToSell(from, 2e8);
 
         (shouldKick, data) = swapper.auctionTrigger(from);
         assertFalse(shouldKick);

--- a/src/test/BaseConvertor.t.sol
+++ b/src/test/BaseConvertor.t.sol
@@ -49,7 +49,7 @@ contract BaseConvertorTest is Setup {
         convertorStrategy.acceptManagement();
 
         vm.startPrank(management);
-        convertor.setMinAmountToSell(1);
+        convertor.setMinAmountToSell(address(asset), 1);
         convertor.setDoHealthCheck(false);
         vm.stopPrank();
     }
@@ -176,6 +176,38 @@ contract BaseConvertorTest is Setup {
         assertEq(convertor.maxAmountToSwap(address(asset)), 42);
     }
 
+    function test_setMinAmountToSell_perToken() public {
+        assertEq(convertor.minAmountToSell(address(asset)), 1);
+        assertEq(convertor.minAmountToSell(address(want)), 0);
+
+        vm.prank(management);
+        convertor.setMinAmountToSell(address(want), 42);
+
+        assertEq(convertor.minAmountToSell(address(asset)), 1);
+        assertEq(convertor.minAmountToSell(address(want)), 42);
+    }
+
+    function test_auctionTrigger_usesTokenMinAmountToSell() public {
+        uint256 assetAmount = 100 * 10 ** asset.decimals();
+        uint256 wantAmount = 100 * 10 ** want.decimals();
+
+        airdrop(asset, address(convertor), assetAmount);
+        airdrop(want, address(convertor), wantAmount);
+
+        vm.startPrank(management);
+        convertor.setMinAmountToSell(address(asset), assetAmount + 1);
+        convertor.setMinAmountToSell(address(want), 1);
+        vm.stopPrank();
+
+        (bool shouldKick, bytes memory data) = convertor.auctionTrigger(
+            address(asset)
+        );
+
+        assertFalse(shouldKick);
+        assertEq(data, bytes("not enough kickable"));
+        assertEq(convertor.minAmountToSell(address(want)), 1);
+    }
+
     function test_kickable_maxAmountToSwap_capsAssetAmount() public {
         uint256 amount = 100 * 10 ** asset.decimals();
         uint256 cap = 40 * 10 ** asset.decimals();
@@ -196,7 +228,7 @@ contract BaseConvertorTest is Setup {
 
         vm.startPrank(management);
         convertor.setMaxAmountToSwap(address(asset), cap);
-        convertor.setMinAmountToSell(cap + 1);
+        convertor.setMinAmountToSell(address(asset), cap + 1);
         vm.stopPrank();
 
         (bool shouldKick, bytes memory data) = convertor.auctionTrigger(address(asset));
@@ -436,7 +468,7 @@ contract BaseConvertorTest is Setup {
         convertor18Strategy.acceptManagement();
 
         vm.startPrank(management);
-        convertor18.setMinAmountToSell(1);
+        convertor18.setMinAmountToSell(address(asset), 1);
         convertor18.setDoHealthCheck(false);
         convertor18.setStartingPriceBps(10_000);
         convertor18.setMaxSlippageBps(500);
@@ -536,7 +568,7 @@ contract BaseConvertorTest is Setup {
         _strategy.acceptManagement();
 
         vm.startPrank(management);
-        _convertor.setMinAmountToSell(1);
+        _convertor.setMinAmountToSell(address(_asset), 1);
         _convertor.setDoHealthCheck(false);
         _convertor.setStartingPriceBps(_case.startingBps);
         _convertor.setMaxSlippageBps(_case.maxSlippageBps);

--- a/src/test/BaseConvertor.t.sol
+++ b/src/test/BaseConvertor.t.sol
@@ -38,7 +38,7 @@ contract BaseConvertorTest is Setup {
         oracle = new MockConvertorOracle();
         oracle.setPrice(1e36); // 1 asset per 1 want
 
-        convertor = new BaseConvertor(address(asset), "Base Convertor", address(want), address(oracle));
+        convertor = new BaseConvertor(address(asset), "Base Convertor", address(want), address(oracle), daddy);
         convertorStrategy = IStrategy(address(convertor));
 
         convertorStrategy.setKeeper(keeper);
@@ -185,6 +185,20 @@ contract BaseConvertorTest is Setup {
 
         assertEq(convertor.minAmountToSell(address(asset)), 1);
         assertEq(convertor.minAmountToSell(address(want)), 42);
+    }
+
+    function test_setOracle_onlyGov() public {
+        MockConvertorOracle newOracle = new MockConvertorOracle();
+        newOracle.setPrice(1e36);
+
+        vm.prank(management);
+        vm.expectRevert(bytes("!gov"));
+        convertor.setOracle(address(newOracle));
+
+        vm.prank(daddy);
+        convertor.setOracle(address(newOracle));
+
+        assertEq(convertor.oracle(), address(newOracle));
     }
 
     function test_auctionTrigger_usesTokenMinAmountToSell() public {
@@ -414,8 +428,10 @@ contract BaseConvertorTest is Setup {
         vm.startPrank(management);
         convertor.setStartingPriceBps(10_000);
         convertor.setMaxSlippageBps(500);
-        convertor.setOracle(address(oracle));
         vm.stopPrank();
+
+        vm.prank(daddy);
+        convertor.setOracle(address(oracle));
 
         oracle.setPrice(2e36); // 2 assets per 1 want
 
@@ -458,7 +474,7 @@ contract BaseConvertorTest is Setup {
         oracle18.setPrice(2_000e24); // 1 WETH => 2,000 USDT
 
         BaseConvertor convertor18 =
-            new BaseConvertor(address(asset), "Base Convertor 18d", address(want18), address(oracle18));
+            new BaseConvertor(address(asset), "Base Convertor 18d", address(want18), address(oracle18), daddy);
         IStrategy convertor18Strategy = IStrategy(address(convertor18));
         convertor18Strategy.setKeeper(keeper);
         convertor18Strategy.setPerformanceFeeRecipient(performanceFeeRecipient);
@@ -558,7 +574,7 @@ contract BaseConvertorTest is Setup {
         _oracle.setPrice(_case.oraclePrice);
 
         BaseConvertor _convertor =
-            new BaseConvertor(address(_asset), "Decimal Pricing Convertor", address(_want), address(_oracle));
+            new BaseConvertor(address(_asset), "Decimal Pricing Convertor", address(_want), address(_oracle), daddy);
         IStrategy _strategy = IStrategy(address(_convertor));
         _strategy.setKeeper(keeper);
         _strategy.setPerformanceFeeRecipient(performanceFeeRecipient);

--- a/src/test/BaseConvertor.t.sol
+++ b/src/test/BaseConvertor.t.sol
@@ -178,7 +178,7 @@ contract BaseConvertorTest is Setup {
 
     function test_setMinAmountToSell_perToken() public {
         assertEq(convertor.minAmountToSell(address(asset)), 1);
-        assertEq(convertor.minAmountToSell(address(want)), 0);
+        assertEq(convertor.minAmountToSell(address(want)), type(uint256).max);
 
         vm.prank(management);
         convertor.setMinAmountToSell(address(want), 42);

--- a/src/test/BaseConvertor4626.t.sol
+++ b/src/test/BaseConvertor4626.t.sol
@@ -30,7 +30,7 @@ contract BaseConvertor4626Test is Setup {
         oracle.setPrice(1e36); // 1 asset per 1 want
 
         convertor = new BaseConvertor4626(
-            address(asset), "Base Convertor 4626", address(want), address(oracle), address(targetVault)
+            address(asset), "Base Convertor 4626", address(want), address(oracle), address(targetVault), daddy
         );
         convertorInterface = IBaseConvertor4626(address(convertor));
         convertorStrategy = IStrategy(address(convertor));

--- a/src/test/BaseConvertor4626.t.sol
+++ b/src/test/BaseConvertor4626.t.sol
@@ -43,7 +43,8 @@ contract BaseConvertor4626Test is Setup {
         convertorStrategy.acceptManagement();
 
         vm.startPrank(management);
-        convertor.setMinAmountToSell(1);
+        convertor.setMinAmountToSell(address(asset), 1);
+        convertor.setMinAmountToSell(address(want), 1);
         convertor.setDoHealthCheck(false);
         vm.stopPrank();
     }
@@ -255,6 +256,35 @@ contract BaseConvertor4626Test is Setup {
         assertEq(kicked, cap);
         assertEq(want.balanceOf(address(convertor)), amount - cap);
         assertEq(want.balanceOf(address(convertor.BUY_ASSET_AUCTION())), cap);
+    }
+
+    function test_kickAuction_blocksVaultTokenButAllowsAsset() public {
+        uint256 amount = 100 * 10 ** asset.decimals();
+
+        airdrop(asset, address(convertor), amount);
+
+        vm.prank(keeper);
+        uint256 kicked = convertor.kickAuction(address(asset));
+
+        assertEq(kicked, amount);
+        assertTrue(convertor.SELL_ASSET_AUCTION().isActive(address(asset)));
+
+        vm.prank(keeper);
+        vm.expectRevert("protected token");
+        convertor.kickAuction(address(targetVault));
+    }
+
+    function test_kickable_returnsZeroForVaultToken() public {
+        uint256 amount = 100 * 10 ** want.decimals();
+
+        airdrop(want, address(convertor), amount);
+
+        vm.prank(keeper);
+        convertor.deployLooseWant();
+
+        assertGt(convertor.balanceOfVault(), 0);
+        assertEq(convertor.kickable(address(targetVault)), 0);
+        assertEq(convertor.kickable(address(want)), 0);
     }
 
     function test_report_accountsVaultAndAuctionBalances(uint256 _amount) public {

--- a/src/test/BaseConvertor4626.t.sol
+++ b/src/test/BaseConvertor4626.t.sol
@@ -287,6 +287,27 @@ contract BaseConvertor4626Test is Setup {
         assertEq(convertor.kickable(address(want)), 0);
     }
 
+    function test_enableAuctionToken_revertsForVault() public {
+        vm.prank(management);
+        vm.expectRevert("protected token");
+        convertor.enableAuctionToken(address(targetVault));
+    }
+
+    function test_enableAuctionToken_allowsNonProtectedToken() public {
+        address dai = tokenAddrs["DAI"];
+        Auction sellAuction = convertor.SELL_ASSET_AUCTION();
+
+        // Not yet enabled.
+        (, uint64 scalerBefore,) = sellAuction.auctions(dai);
+        assertEq(scalerBefore, 0);
+
+        vm.prank(management);
+        convertor.enableAuctionToken(dai);
+
+        (, uint64 scalerAfter,) = sellAuction.auctions(dai);
+        assertGt(scalerAfter, 0);
+    }
+
     function test_report_accountsVaultAndAuctionBalances(uint256 _amount) public {
         vm.assume(_amount > 1e8 && _amount < maxFuzzAmount);
 

--- a/src/test/Convertor4626Factory.t.sol
+++ b/src/test/Convertor4626Factory.t.sol
@@ -27,12 +27,13 @@ contract Convertor4626FactoryTest is Setup {
         MockStrategy vault = new MockStrategy(want);
 
         address deployed =
-            factory.newConvertor4626(address(asset), "Factory 4626 Convertor", want, address(oracle), address(vault));
+            factory.newConvertor4626(address(asset), "Factory 4626 Convertor", want, address(oracle), address(vault), daddy);
 
         IBaseConvertor4626 convertor = IBaseConvertor4626(deployed);
 
         assertEq(convertor.asset(), address(asset));
         assertEq(address(convertor.WANT()), want);
+        assertEq(convertor.GOV(), daddy);
         assertEq(convertor.oracle(), address(oracle));
         assertEq(address(convertor.vault()), address(vault));
         assertEq(convertor.performanceFeeRecipient(), performanceFeeRecipient);
@@ -49,10 +50,10 @@ contract Convertor4626FactoryTest is Setup {
         MockStrategy vault = new MockStrategy(want);
 
         address deployed =
-            factory.newConvertor4626(address(asset), "Factory 4626 Convertor", want, address(oracle), address(vault));
+            factory.newConvertor4626(address(asset), "Factory 4626 Convertor", want, address(oracle), address(vault), daddy);
 
         vm.expectRevert(abi.encodeWithSelector(Convertor4626Factory.AlreadyDeployed.selector, deployed));
-        factory.newConvertor4626(address(asset), "Factory 4626 Convertor", want, address(oracle), address(vault));
+        factory.newConvertor4626(address(asset), "Factory 4626 Convertor", want, address(oracle), address(vault), daddy);
     }
 
     function test_setAddresses_onlyManagement() public {

--- a/src/test/ConvertorFactory.t.sol
+++ b/src/test/ConvertorFactory.t.sol
@@ -24,12 +24,13 @@ contract ConvertorFactoryTest is Setup {
     function test_newConvertor_deploysAndConfiguresStrategy() public {
         address want = tokenAddrs["USDC"];
 
-        address deployed = factory.newConvertor(address(asset), "Factory Base Convertor", want, address(oracle));
+        address deployed = factory.newConvertor(address(asset), "Factory Base Convertor", want, address(oracle), daddy);
 
         IBaseConvertor convertor = IBaseConvertor(deployed);
 
         assertEq(convertor.asset(), address(asset));
         assertEq(address(convertor.WANT()), want);
+        assertEq(convertor.GOV(), daddy);
         assertEq(convertor.oracle(), address(oracle));
         assertEq(convertor.performanceFeeRecipient(), performanceFeeRecipient);
         assertEq(convertor.keeper(), keeper);
@@ -43,10 +44,10 @@ contract ConvertorFactoryTest is Setup {
     function test_newConvertor_revertsOnDuplicateDeployment() public {
         address want = tokenAddrs["USDC"];
 
-        address deployed = factory.newConvertor(address(asset), "Factory Base Convertor", want, address(oracle));
+        address deployed = factory.newConvertor(address(asset), "Factory Base Convertor", want, address(oracle), daddy);
 
         vm.expectRevert(abi.encodeWithSelector(ConvertorFactory.AlreadyDeployed.selector, deployed));
-        factory.newConvertor(address(asset), "Factory Base Convertor", want, address(oracle));
+        factory.newConvertor(address(asset), "Factory Base Convertor", want, address(oracle), daddy);
     }
 
     function test_setAddresses_onlyManagement() public {

--- a/src/test/CurveSwapper.t.sol
+++ b/src/test/CurveSwapper.t.sol
@@ -136,7 +136,7 @@ contract CurveSwapperTest is Setup {
         vm.assume(amount >= minWethAmount && amount <= maxWethAmount);
 
         // Set minAmountToSell above our swap amount
-        curveSwapper.setMinAmountToSell(amount + 1);
+        curveSwapper.setMinAmountToSell(address(weth), amount + 1);
 
         airdrop(weth, address(curveSwapper), amount);
 

--- a/src/test/FluidSwapper.t.sol
+++ b/src/test/FluidSwapper.t.sol
@@ -131,7 +131,7 @@ contract FluidSwapperTest is Setup {
         vm.assume(amount >= minUsdtAmount && amount <= maxUsdtAmount);
 
         vm.prank(management);
-        fluidSwapper.setMinAmountToSell(amount + 1);
+        fluidSwapper.setMinAmountToSell(address(asset), amount + 1);
 
         airdrop(asset, address(fluidSwapper), amount);
 

--- a/src/test/PendleSwapper.t.sol
+++ b/src/test/PendleSwapper.t.sol
@@ -79,9 +79,9 @@ contract PendleSwapperTest is Setup {
 
         // Set min amount to sell higher than our amount
         vm.prank(management);
-        pendleSwapper.setMinAmountToSell(1e16);
+        pendleSwapper.setMinAmountToSell(address(mockAsset), 1e16);
 
-        assertEq(pendleSwapper.minAmountToSell(), 1e16);
+        assertEq(pendleSwapper.minAmountToSell(address(mockAsset)), 1e16);
 
         // Mint tokens to the swapper
         mockAsset.mint(address(pendleSwapper), amount);
@@ -123,7 +123,7 @@ contract PendleSwapperTest is Setup {
 
     function test_defaultMinAmountToSell() public {
         // Verify default minAmountToSell is 0
-        assertEq(pendleSwapper.minAmountToSell(), 0);
+        assertEq(pendleSwapper.minAmountToSell(address(mockAsset)), 0);
     }
 
     function test_defaultGuessMaxMultiplier() public {
@@ -338,7 +338,7 @@ contract PendleSwapperForkTest is Setup {
 
         // Set minAmountToSell higher than our swap amount
         vm.prank(management);
-        pendleSwapper.setMinAmountToSell(2000e6); // 2000 USDC minimum
+        pendleSwapper.setMinAmountToSell(address(usdc), 2000e6); // 2000 USDC minimum
 
         // Airdrop USDC to the swapper
         airdrop(usdc, address(pendleSwapper), amount);

--- a/src/test/UniswapUniversalSwapper.t.sol
+++ b/src/test/UniswapUniversalSwapper.t.sol
@@ -36,7 +36,7 @@ contract UniswapUniversalSwapperTest is Setup {
     }
 
     function test_defaultMinAmountToSell() public {
-        assertEq(swapper.minAmountToSell(), 0);
+        assertEq(swapper.minAmountToSell(address(asset)), 0);
     }
 
     function test_setUniFees() public {
@@ -94,7 +94,7 @@ contract UniswapUniversalSwapperTest is Setup {
         swapper.setUniFees(address(asset), WETH, 3000);
 
         vm.prank(management);
-        swapper.setMinAmountToSell(1e18);
+        swapper.setMinAmountToSell(address(asset), 1e18);
 
         uint256 amount = 1e15;
         airdrop(asset, address(swapper), amount);

--- a/src/test/mocks/MockAuctionSwapper.sol
+++ b/src/test/mocks/MockAuctionSwapper.sol
@@ -11,6 +11,8 @@ contract MockAuctionSwapper is BaseStrategy, AuctionSwapper {
 
     uint256 public letKick;
 
+    address[] internal _protectedTokens;
+
     constructor(address _asset) BaseStrategy(_asset, "Mock Uni V3") {}
 
     function _deployFunds(uint256) internal override {}
@@ -33,12 +35,27 @@ contract MockAuctionSwapper is BaseStrategy, AuctionSwapper {
         _setMinAmountToSell(_minAmountToSell);
     }
 
+    function protectedTokens() public view override returns (address[] memory) {
+        return _protectedTokens;
+    }
+
+    function setProtectedTokens(address[] calldata _tokens) external {
+        delete _protectedTokens;
+
+        uint256 length = _tokens.length;
+        for (uint256 i; i < length; ++i) {
+            _protectedTokens.push(_tokens[i]);
+        }
+    }
+
     function kickable(address _token) public view override returns (uint256) {
+        if (_isProtectedToken(_token)) return 0;
         if (useDefault) return super.kickable(_token);
         return letKick;
     }
 
     function kickAuction(address _token) external override returns (uint256) {
+        require(!_isProtectedToken(_token), "protected token");
         if (useDefault) return _kickAuction(_token);
 
         ERC20(_token).safeTransfer(auction, letKick);
@@ -63,6 +80,8 @@ interface IMockAuctionSwapper is IStrategy, IAuctionSwapper {
     function setUseAuction(bool _useAuction) external;
 
     function setMinAmountToSell(uint256 _minAmountToSell) external;
+
+    function setProtectedTokens(address[] calldata _tokens) external;
 
     function useDefault() external view returns (bool);
 

--- a/src/test/mocks/MockAuctionSwapper.sol
+++ b/src/test/mocks/MockAuctionSwapper.sol
@@ -31,8 +31,11 @@ contract MockAuctionSwapper is BaseStrategy, AuctionSwapper {
         _setUseAuction(_useAuction);
     }
 
-    function setMinAmountToSell(uint256 _minAmountToSell) external {
-        _setMinAmountToSell(_minAmountToSell);
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external {
+        _setMinAmountToSell(_token, _minAmountToSell);
     }
 
     function protectedTokens() public view override returns (address[] memory) {
@@ -79,7 +82,10 @@ interface IMockAuctionSwapper is IStrategy, IAuctionSwapper {
 
     function setUseAuction(bool _useAuction) external;
 
-    function setMinAmountToSell(uint256 _minAmountToSell) external;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external;
 
     function setProtectedTokens(address[] calldata _tokens) external;
 

--- a/src/test/mocks/MockCurveSwapper.sol
+++ b/src/test/mocks/MockCurveSwapper.sol
@@ -4,8 +4,11 @@ pragma solidity >=0.8.18;
 import {CurveSwapper} from "../../swappers/CurveSwapper.sol";
 
 contract MockCurveSwapper is CurveSwapper {
-    function setMinAmountToSell(uint256 _minAmountToSell) external {
-        minAmountToSell = _minAmountToSell;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external {
+        _setMinAmountToSell(_token, _minAmountToSell);
     }
 
     function setRouter(address _router) external {

--- a/src/test/mocks/MockFluidSwapper.sol
+++ b/src/test/mocks/MockFluidSwapper.sol
@@ -18,8 +18,11 @@ contract MockFluidSwapper is BaseStrategy, FluidSwapper {
         _totalAssets = asset.balanceOf(address(this));
     }
 
-    function setMinAmountToSell(uint256 _minAmountToSell) external {
-        minAmountToSell = _minAmountToSell;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external {
+        _setMinAmountToSell(_token, _minAmountToSell);
     }
 
     function setBase(address _base) external {
@@ -50,7 +53,10 @@ import {IStrategy} from "@tokenized-strategy/interfaces/IStrategy.sol";
 import {IFluidSwapper} from "../../swappers/interfaces/IFluidSwapper.sol";
 
 interface IMockFluidSwapper is IStrategy, IFluidSwapper {
-    function setMinAmountToSell(uint256 _minAmountToSell) external;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external;
 
     function setBase(address _base) external;
 

--- a/src/test/mocks/MockPendleSwapper.sol
+++ b/src/test/mocks/MockPendleSwapper.sol
@@ -17,8 +17,11 @@ contract MockPendleSwapper is BaseStrategy, PendleSwapper {
         _totalAssets = asset.balanceOf(address(this));
     }
 
-    function setMinAmountToSell(uint256 _minAmountToSell) external {
-        minAmountToSell = _minAmountToSell;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external {
+        _setMinAmountToSell(_token, _minAmountToSell);
     }
 
     function setMarket(address _pt, address _market) external {
@@ -48,8 +51,11 @@ contract MockPendleSwapperWithAggregator is BaseStrategy, PendleSwapperWithAggre
         _totalAssets = asset.balanceOf(address(this));
     }
 
-    function setMinAmountToSell(uint256 _minAmountToSell) external {
-        minAmountToSell = _minAmountToSell;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external {
+        _setMinAmountToSell(_token, _minAmountToSell);
     }
 
     function setMarket(address _pt, address _market) external {
@@ -94,7 +100,10 @@ import {IStrategy} from "@tokenized-strategy/interfaces/IStrategy.sol";
 import {IPendleSwapper} from "../../swappers/interfaces/IPendleSwapper.sol";
 
 interface IMockPendleSwapper is IStrategy, IPendleSwapper {
-    function setMinAmountToSell(uint256 _minAmountToSell) external;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external;
 
     function setMarket(address _pt, address _market) external;
 

--- a/src/test/mocks/MockSolidlySwapper.sol
+++ b/src/test/mocks/MockSolidlySwapper.sol
@@ -15,8 +15,11 @@ contract MockSolidlySwapper is BaseStrategy, SolidlySwapper {
         _totalAssets = asset.balanceOf(address(this));
     }
 
-    function setMinAmountToSell(uint256 _minAmountToSell) external {
-        minAmountToSell = _minAmountToSell;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external {
+        _setMinAmountToSell(_token, _minAmountToSell);
     }
 
     function setRouter(address _router) external {
@@ -40,7 +43,10 @@ import {IStrategy} from "@tokenized-strategy/interfaces/IStrategy.sol";
 import {ISolidlySwapper} from "../../swappers/interfaces/ISolidlySwapper.sol";
 
 interface IMockSolidlySwapper is IStrategy, ISolidlySwapper {
-    function setMinAmountToSell(uint256 _minAmountToSell) external;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external;
 
     function setRouter(address _router) external;
 

--- a/src/test/mocks/MockUniswapUniversalSwapper.sol
+++ b/src/test/mocks/MockUniswapUniversalSwapper.sol
@@ -25,8 +25,11 @@ contract MockUniswapUniversalSwapper is BaseStrategy, UniswapUniversalSwapper {
 
     // Expose internal setters for testing
 
-    function setMinAmountToSell(uint256 _minAmountToSell) external {
-        minAmountToSell = _minAmountToSell;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external {
+        _setMinAmountToSell(_token, _minAmountToSell);
     }
 
     function setBase(address _base) external {
@@ -54,7 +57,10 @@ import {IStrategy} from "@tokenized-strategy/interfaces/IStrategy.sol";
 import {IUniswapUniversalSwapper} from "../../swappers/interfaces/IUniswapUniversalSwapper.sol";
 
 interface IMockUniswapUniversalSwapper is IStrategy, IUniswapUniversalSwapper {
-    function setMinAmountToSell(uint256 _minAmountToSell) external;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external;
 
     function setBase(address _base) external;
 

--- a/src/test/mocks/MockUniswapV2Swapper.sol
+++ b/src/test/mocks/MockUniswapV2Swapper.sol
@@ -15,8 +15,11 @@ contract MockUniswapV2Swapper is BaseStrategy, UniswapV2Swapper {
         _totalAssets = asset.balanceOf(address(this));
     }
 
-    function setMinAmountToSell(uint256 _minAmountToSell) external {
-        minAmountToSell = _minAmountToSell;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external {
+        _setMinAmountToSell(_token, _minAmountToSell);
     }
 
     function setRouter(address _router) external {
@@ -36,7 +39,10 @@ import {IStrategy} from "@tokenized-strategy/interfaces/IStrategy.sol";
 import {IUniswapV2Swapper} from "../../swappers/interfaces/IUniswapV2Swapper.sol";
 
 interface IMockUniswapV2Swapper is IStrategy, IUniswapV2Swapper {
-    function setMinAmountToSell(uint256 _minAmountToSell) external;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external;
 
     function setRouter(address _router) external;
 

--- a/src/test/mocks/MockUniswapV3Swapper.sol
+++ b/src/test/mocks/MockUniswapV3Swapper.sol
@@ -15,8 +15,11 @@ contract MockUniswapV3Swapper is BaseStrategy, UniswapV3Swapper {
         _totalAssets = asset.balanceOf(address(this));
     }
 
-    function setMinAmountToSell(uint256 _minAmountToSell) external {
-        minAmountToSell = _minAmountToSell;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external {
+        _setMinAmountToSell(_token, _minAmountToSell);
     }
 
     function setRouter(address _router) external {
@@ -44,7 +47,10 @@ import {IStrategy} from "@tokenized-strategy/interfaces/IStrategy.sol";
 import {IUniswapV3Swapper} from "../../swappers/interfaces/IUniswapV3Swapper.sol";
 
 interface IMockUniswapV3Swapper is IStrategy, IUniswapV3Swapper {
-    function setMinAmountToSell(uint256 _minAmountToSell) external;
+    function setMinAmountToSell(
+        address _token,
+        uint256 _minAmountToSell
+    ) external;
 
     function setRouter(address _router) external;
 


### PR DESCRIPTION
## Summary

- Protect auction kicks from configured protected tokens.
- Block 4626 converter vault tokens from `kickAuction` and `kickable`.
- Make converter and base swapper minimum sell amounts token-specific.
