### PR TITLE
fix: prevent auction swapper self kicks

### DIFF
--- a/src/swappers/AuctionSwapper.sol
+++ b/src/swappers/AuctionSwapper.sol
@@ -119,7 +119,7 @@ abstract contract AuctionSwapper is BaseSwapper {
      * @param _from The token that was being sold.
      */
     function _kickAuction(address _from) internal virtual returns (uint256) {
-        require(!_isProtectedToken(_from), "protected token");
+        require(_from != address(this) && !_isProtectedToken(_from), "protected token");
         require(useAuction, "useAuction is false");
         address _auction = auction;
 

--- a/src/test/AuctionSwapper.t.sol
+++ b/src/test/AuctionSwapper.t.sol
@@ -221,6 +221,17 @@ contract AuctionSwapperTest is Setup {
         assertEq(ERC20(from).balanceOf(address(auction)), 0);
     }
 
+    function test_kickAuction_selfAddressRevertsWithoutProtectedTokenEntry() public {
+        address newAuction = auctionFactory.createNewAuction(address(asset), address(swapper), address(this), 1e6);
+        swapper.setAuction(newAuction);
+
+        address[] memory configuredTokens = swapper.protectedTokens();
+        assertEq(configuredTokens.length, 0);
+
+        vm.expectRevert("protected token");
+        swapper.kickAuction(address(swapper));
+    }
+
     function test_kickAuction_default(uint256 _amount) public {
         vm.assume(_amount >= minFuzzAmount && _amount <= maxFuzzAmount);
 


### PR DESCRIPTION
## Summary
- block `address(this)` in `AuctionSwapper._kickAuction` without adding it to `protectedTokens()`
- add regression coverage for self-kick rejection with an empty protected token list

## Tests
- `forge test --match-contract AuctionSwapperTest --fork-url "$ETH_RPC_URL"`